### PR TITLE
Fixing linter warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ MessageBird's REST API for Go
 This repository contains the open source Go client for MessageBird's REST API. Documentation can be found at: https://www.messagebird.com/developers/go.
 
 [![Build Status](https://travis-ci.org/messagebird/go-rest-api.svg?branch=master)](https://travis-ci.org/messagebird/go-rest-api)
+[![Go Report Card](https://goreportcard.com/badge/github.com/messagebird/go-rest-api)](https://goreportcard.com/report/github.com/messagebird/go-rest-api)
 
 Requirements
 ------------

--- a/balance.go
+++ b/balance.go
@@ -1,5 +1,6 @@
 package messagebird
 
+// Balance object represents your balance at MessageBird.com
 type Balance struct {
 	Payment string
 	Type    string

--- a/balance.go
+++ b/balance.go
@@ -1,6 +1,6 @@
 package messagebird
 
-// Balance object represents your balance at MessageBird.com
+// Balance describes your balance information.
 type Balance struct {
 	Payment string
 	Type    string

--- a/balance_test.go
+++ b/balance_test.go
@@ -2,7 +2,7 @@ package messagebird
 
 import "testing"
 
-var balanceObject []byte = []byte(`{
+var balanceObject = []byte(`{
   "payment":"prepaid",
   "type":"credits",
   "amount":9.2

--- a/client.go
+++ b/client.go
@@ -18,15 +18,23 @@ import (
 )
 
 const (
+	// ClientVersion is used in User-Agent request header to provide server with API level.
 	ClientVersion = "2.3.0"
-	Endpoint      = "https://rest.messagebird.com"
+
+	// Endpoint points you to MessageBird REST API.
+	Endpoint = "https://rest.messagebird.com"
 )
 
 var (
-	ErrResponse           = errors.New("The MessageBird API returned an error")
+	// ErrResponse is returned when we were able to cntact API but request was not successful and containes error details.
+	ErrResponse = errors.New("The MessageBird API returned an error")
+
+	// ErrUnexpectedResponse is used when there was an internal server error and nothing can be done at this point.
 	ErrUnexpectedResponse = errors.New("The MessageBird API is currently unavailable")
 )
 
+// Client is used to access API with a given key.
+// Uses standard lib HTTP client internally, so should be reused instead of created as needed and it is safe for concurrent use.
 type Client struct {
 	AccessKey  string       // The API access key
 	HTTPClient *http.Client // The HTTP client to send requests on

--- a/client.go
+++ b/client.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	// ErrResponse is returned when we were able to cntact API but request was not successful and containes error details.
+	// ErrResponse is returned when we were able to contact API but request was not successful and containes error details.
 	ErrResponse = errors.New("The MessageBird API returned an error")
 
 	// ErrUnexpectedResponse is used when there was an internal server error and nothing can be done at this point.

--- a/client.go
+++ b/client.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	// ErrResponse is returned when we were able to contact API but request was not successful and containes error details.
+	// ErrResponse is returned when we were able to contact API but request was not successful and contains error details.
 	ErrResponse = errors.New("The MessageBird API returned an error")
 
 	// ErrUnexpectedResponse is used when there was an internal server error and nothing can be done at this point.

--- a/client.go
+++ b/client.go
@@ -4,6 +4,9 @@
 //
 // Author: Maurice Nonnekes <maurice@messagebird.com>
 
+// Package messagebird is an official library for interacting with MessageBird.com API.
+// The MessageBird API connects your website or application to operators around the world. With our API you can integrate SMS, Chat & Voice.
+// More documentation you can find on the MessageBird developers portal: https://developers.messagebird.com/
 package messagebird
 
 import (

--- a/error.go
+++ b/error.go
@@ -1,5 +1,6 @@
 package messagebird
 
+// Error holds details including error code, human readable description and optional parameter that is related to the error.
 type Error struct {
 	Code        int
 	Description string

--- a/hlr.go
+++ b/hlr.go
@@ -3,7 +3,7 @@ package messagebird
 import "time"
 
 type HLR struct {
-	Id              string
+	ID              string
 	HRef            string
 	MSISDN          int
 	Network         int

--- a/hlr.go
+++ b/hlr.go
@@ -2,6 +2,8 @@ package messagebird
 
 import "time"
 
+// HLR stands for Home Location Register.
+// Contains information about the subscribers identity, telephone number, the associated services and general information about the location of the subscriber
 type HLR struct {
 	ID              string
 	HRef            string

--- a/hlr_test.go
+++ b/hlr_test.go
@@ -17,8 +17,8 @@ var hlrObject = []byte(`{
 }`)
 
 func assertHLRObject(t *testing.T, hlr *HLR) {
-	if hlr.Id != "27978c50354a93ca0ca8de6h54340177" {
-		t.Errorf("Unexpected result for HLR Id: %s", hlr.Id)
+	if hlr.ID != "27978c50354a93ca0ca8de6h54340177" {
+		t.Errorf("Unexpected result for HLR Id: %s", hlr.ID)
 	}
 
 	if hlr.HRef != "https://rest.messagebird.com/hlr/27978c50354a93ca0ca8de6h54340177" {

--- a/hlr_test.go
+++ b/hlr_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-var hlrObject []byte = []byte(`{
+var hlrObject = []byte(`{
   "id":"27978c50354a93ca0ca8de6h54340177",
   "href":"https:\/\/rest.messagebird.com\/hlr\/27978c50354a93ca0ca8de6h54340177",
   "msisdn":31612345678,

--- a/lookup.go
+++ b/lookup.go
@@ -2,6 +2,7 @@ package messagebird
 
 import "net/url"
 
+// Formats represents phone number in multiple formats.
 type Formats struct {
 	E164          string
 	International string
@@ -9,6 +10,7 @@ type Formats struct {
 	Rfc3966       string
 }
 
+// Lookup is used to validate and look up a mobile number.
 type Lookup struct {
 	Href          string
 	CountryCode   string
@@ -19,6 +21,7 @@ type Lookup struct {
 	HLR           *HLR
 }
 
+// LookupParams provide additional lookup information.
 type LookupParams struct {
 	CountryCode string
 	Reference   string

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -66,8 +66,8 @@ func TestLookup(t *testing.T) {
 }
 
 func checkHLR(t *testing.T, hlr *HLR) {
-	if hlr.Id != "6118d3f06566fcd0cdc8962h65065907" {
-		t.Errorf("Unexpected hlr id: %s", hlr.Id)
+	if hlr.ID != "6118d3f06566fcd0cdc8962h65065907" {
+		t.Errorf("Unexpected hlr id: %s", hlr.ID)
 	}
 	if hlr.Network != 20416 {
 		t.Errorf("Unexpected hlr network: %d", hlr.Network)

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -49,7 +49,7 @@ func TestLookup(t *testing.T) {
 		t.Errorf("Unexpected lookup href: %s", lookup.Href)
 	}
 	if strconv.FormatInt(lookup.PhoneNumber, 10) != phoneNumber {
-		t.Errorf("Unexpected lookup phoneNumber: %s", lookup.PhoneNumber)
+		t.Errorf("Unexpected lookup phoneNumber: %d", lookup.PhoneNumber)
 	}
 
 	if lookup.Formats.International != "+31 6 24971134" {

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var lookupObject []byte = []byte(`{
+var lookupObject = []byte(`{
     "href":"https://rest.messagebird.com/lookup/31624971134",
     "countryCode":"NL",
     "countryPrefix":31,
@@ -27,7 +27,7 @@ var lookupObject []byte = []byte(`{
     }
 }`)
 
-var lookupHLRObject []byte = []byte(`{
+var lookupHLRObject = []byte(`{
     "id":"6118d3f06566fcd0cdc8962h65065907",
     "network":20416,
     "reference":"referece2000",

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,7 @@ var mbServer *httptest.Server
 var mbServerResponseCode int
 var mbServerResponseBody []byte
 
-var accessKeyErrorObject []byte = []byte(`{
+var accessKeyErrorObject = []byte(`{
   "errors":[
     {
       "code":2,

--- a/message.go
+++ b/message.go
@@ -10,7 +10,7 @@ import (
 type TypeDetails map[string]interface{}
 
 type Message struct {
-	Id                string
+	ID                string
 	HRef              string
 	Direction         string
 	Type              string

--- a/message.go
+++ b/message.go
@@ -7,8 +7,11 @@ import (
 	"time"
 )
 
+// TypeDetails is a hash with extra information.
+// Is only used when a binary or premium message is sent.
 type TypeDetails map[string]interface{}
 
+// Message struct represents a message at MessageBird.com
 type Message struct {
 	ID                string
 	HRef              string
@@ -28,6 +31,7 @@ type Message struct {
 	Errors            []Error
 }
 
+// MessageParams provide additional message send options and used in URL as params.
 type MessageParams struct {
 	Type              string
 	Reference         string

--- a/message_test.go
+++ b/message_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-var messageObject []byte = []byte(`{
+var messageObject = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
   "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",
@@ -147,7 +147,7 @@ func TestNewMessageError(t *testing.T) {
 	}
 }
 
-var messageWithParamsObject []byte = []byte(`{
+var messageWithParamsObject = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
   "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",
@@ -216,7 +216,7 @@ func TestNewMessageWithParams(t *testing.T) {
 	}
 }
 
-var binaryMessageObject []byte = []byte(`{
+var binaryMessageObject = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
   "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",
@@ -274,7 +274,7 @@ func TestNewMessageWithBinaryType(t *testing.T) {
 	}
 }
 
-var premiumMessageObject []byte = []byte(`{
+var premiumMessageObject = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
   "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",
@@ -342,7 +342,7 @@ func TestNewMessageWithPremiumType(t *testing.T) {
 	}
 }
 
-var flashMessageObject []byte = []byte(`{
+var flashMessageObject = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
   "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",
@@ -389,7 +389,7 @@ func TestNewMessageWithFlashType(t *testing.T) {
 	}
 }
 
-var messageObjectWithCreatedDatetime []byte = []byte(`{
+var messageObjectWithCreatedDatetime = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
   "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",

--- a/message_test.go
+++ b/message_test.go
@@ -45,8 +45,8 @@ func TestNewMessage(t *testing.T) {
 		t.Fatalf("Didn't expect error while creating a new message: %s", err)
 	}
 
-	if message.Id != "6fe65f90454aa61536e6a88b88972670" {
-		t.Errorf("Unexpected message id: %s", message.Id)
+	if message.ID != "6fe65f90454aa61536e6a88b88972670" {
+		t.Errorf("Unexpected message id: %s", message.ID)
 	}
 
 	if message.HRef != "https://rest.messagebird.com/messages/6fe65f90454aa61536e6a88b88972670" {

--- a/message_test.go
+++ b/message_test.go
@@ -78,7 +78,7 @@ func TestNewMessage(t *testing.T) {
 	}
 
 	if message.Gateway != 239 {
-		t.Errorf("Unexpected message gateway: %s", message.Gateway)
+		t.Errorf("Unexpected message gateway: %d", message.Gateway)
 	}
 
 	if len(message.TypeDetails) != 0 {
@@ -90,7 +90,7 @@ func TestNewMessage(t *testing.T) {
 	}
 
 	if message.MClass != 1 {
-		t.Errorf("Unexpected message mclass: %s", message.MClass)
+		t.Errorf("Unexpected message mclass: %d", message.MClass)
 	}
 
 	if message.ScheduledDatetime != nil {
@@ -208,7 +208,7 @@ func TestNewMessageWithParams(t *testing.T) {
 	}
 
 	if message.Gateway != 10 {
-		t.Errorf("Unexpected message gateway: %s", message.Gateway)
+		t.Errorf("Unexpected message gateway: %d", message.Gateway)
 	}
 
 	if message.DataCoding != "unicode" {

--- a/otp_message.go
+++ b/otp_message.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// OtpMessage stands for one time password message.
 type OtpMessage struct {
 	ID                 string
 	Recipient          string
@@ -16,6 +17,7 @@ type OtpMessage struct {
 	Errors             []Error
 }
 
+// OtpParams carry aditional message details and used for URL build.
 type OtpParams struct {
 	Reference  string
 	Originator string

--- a/otp_message.go
+++ b/otp_message.go
@@ -6,7 +6,7 @@ import (
 )
 
 type OtpMessage struct {
-	Id                 string
+	ID                 string
 	Recipient          string
 	Reference          string
 	Status             string

--- a/otp_message_test.go
+++ b/otp_message_test.go
@@ -25,8 +25,8 @@ func TestOtpGenerate(t *testing.T) {
 		t.Fatalf("Didn't expect error while generating an OTP: %s", err)
 	}
 
-	if result.Id != "76d429606554b5827a46b12o29500954" {
-		t.Errorf("Unexpected OTP message id: %s", result.Id)
+	if result.ID != "76d429606554b5827a46b12o29500954" {
+		t.Errorf("Unexpected OTP message id: %s", result.ID)
 	}
 
 	if result.Recipient != "31630174123" {
@@ -79,8 +79,8 @@ func TestOtpVerify(t *testing.T) {
 		t.Fatalf("Didn't expect error while verifying an OTP: %s", err)
 	}
 
-	if result.Id != "8b912ea03554b7a3d5d6e22o95082672" {
-		t.Errorf("Unexpected OTP message id: %s", result.Id)
+	if result.ID != "8b912ea03554b7a3d5d6e22o95082672" {
+		t.Errorf("Unexpected OTP message id: %s", result.ID)
 	}
 
 	if result.Recipient != "31630174123" {

--- a/otp_message_test.go
+++ b/otp_message_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-var OtpGenerateObject []byte = []byte(`{
+var OtpGenerateObject = []byte(`{
     "id": "76d429606554b5827a46b12o29500954",
     "recipient": "31630174123",
     "reference": null,
@@ -59,7 +59,7 @@ func TestOtpGenerate(t *testing.T) {
 	}
 }
 
-var OtpVerifyObject []byte = []byte(`{
+var OtpVerifyObject = []byte(`{
     "id": "8b912ea03554b7a3d5d6e22o95082672",
     "recipient": "31630174123",
     "reference": null,

--- a/recipient.go
+++ b/recipient.go
@@ -2,12 +2,14 @@ package messagebird
 
 import "time"
 
+// Recipient struct holds information for a single msisdn with status details.
 type Recipient struct {
 	Recipient      int
 	Status         string
 	StatusDatetime *time.Time
 }
 
+// Recipients holds a collection of Recepient structs along with send stats.
 type Recipients struct {
 	TotalCount               int
 	TotalSentCount           int

--- a/voice_message.go
+++ b/voice_message.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+// VoiceMessage wraps data needed to transform text messages into voice messages.
+// Voice messages are identified by a unique random ID. With this ID you can always check the status of the voice message through the provided endpoint.
 type VoiceMessage struct {
 	ID                string
 	HRef              string
@@ -22,6 +24,7 @@ type VoiceMessage struct {
 	Errors            []Error
 }
 
+// VoiceMessageParams struct provides additional VoiceMessage details.
 type VoiceMessageParams struct {
 	Originator        string
 	Reference         string

--- a/voice_message.go
+++ b/voice_message.go
@@ -7,7 +7,7 @@ import (
 )
 
 type VoiceMessage struct {
-	Id                string
+	ID                string
 	HRef              string
 	Originator        string
 	Body              string

--- a/voice_message_test.go
+++ b/voice_message_test.go
@@ -73,7 +73,7 @@ func TestNewVoiceMessage(t *testing.T) {
 	}
 
 	if message.IfMachine != "continue" {
-		t.Errorf("Unexpected voice message ifmachine: %d", message.IfMachine)
+		t.Errorf("Unexpected voice message ifmachine: %s", message.IfMachine)
 	}
 
 	if message.ScheduledDatetime != nil {

--- a/voice_message_test.go
+++ b/voice_message_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-var voiceMessageObject []byte = []byte(`{
+var voiceMessageObject = []byte(`{
   "id":"430c44a0354aab7ac9553f7a49907463",
   "href":"https:\/\/rest.messagebird.com\/voicemessages\/430c44a0354aab7ac9553f7a49907463",
   "originator":"MessageBird",
@@ -109,7 +109,7 @@ func TestNewVoiceMessage(t *testing.T) {
 	}
 }
 
-var voiceMessageObjectWithParams []byte = []byte(`{
+var voiceMessageObjectWithParams = []byte(`{
   "id":"430c44a0354aab7ac9553f7a49907463",
   "href":"https:\/\/rest.messagebird.com\/voicemessages\/430c44a0354aab7ac9553f7a49907463",
   "body":"Hello World",
@@ -167,7 +167,7 @@ func TestNewVoiceMessageWithParams(t *testing.T) {
 	}
 }
 
-var voiceMessageObjectWithCreatedDatetime []byte = []byte(`{
+var voiceMessageObjectWithCreatedDatetime = []byte(`{
   "id":"430c44a0354aab7ac9553f7a49907463",
   "href":"https:\/\/rest.messagebird.com\/voicemessages\/430c44a0354aab7ac9553f7a49907463",
   "body":"Hello World",

--- a/voice_message_test.go
+++ b/voice_message_test.go
@@ -40,8 +40,8 @@ func TestNewVoiceMessage(t *testing.T) {
 		t.Fatalf("Didn't expect error while creating a new voice message: %s", err)
 	}
 
-	if message.Id != "430c44a0354aab7ac9553f7a49907463" {
-		t.Errorf("Unexpected voice message id: %s", message.Id)
+	if message.ID != "430c44a0354aab7ac9553f7a49907463" {
+		t.Errorf("Unexpected voice message id: %s", message.ID)
 	}
 
 	if message.HRef != "https://rest.messagebird.com/voicemessages/430c44a0354aab7ac9553f7a49907463" {


### PR DESCRIPTION
Nothing important, just few issues that gometalinter reports.

1. Fixing declarations according to golint complains.
2. Renamed Id to ID according to Go standard.
3. Added godocs to exported structs.
4. Fixed formatted messages.
5. Added goreportcard.