### PR TITLE
Switch from url encoded data to JSON data

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,10 +59,10 @@ func (c *Client) request(v interface{}, path string, data interface{}) error {
 	var jsonEncoded []byte
 	if data != nil {
 		jsonEncoded, err = json.Marshal(data)
-		method = "POST"
 		if err != nil {
 			return err
 		}
+		method = "POST"
 	}
 
 	request, err := http.NewRequest(method, uri.String(), bytes.NewBuffer(jsonEncoded))
@@ -73,7 +73,7 @@ func (c *Client) request(v interface{}, path string, data interface{}) error {
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Authorization", "AccessKey "+c.AccessKey)
-	request.Header.Add("User-Agent", "MessageBird/ApiClient/"+ClientVersion+" Go/"+runtime.Version())
+	request.Header.Set("User-Agent", "MessageBird/ApiClient/"+ClientVersion+" Go/"+runtime.Version())
 
 	if c.DebugLog != nil {
 		if data != nil {

--- a/client.go
+++ b/client.go
@@ -13,7 +13,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -84,13 +83,6 @@ func (c *Client) request(v interface{}, path string, data interface{}) error {
 		}
 	}
 
-	// TODO remove this
-	if data != nil {
-		fmt.Printf("HTTP REQUEST: %s %s %s\n", method, uri.String(), jsonEncoded)
-	} else {
-		fmt.Printf("HTTP REQUEST: %s %s\n", method, uri.String())
-	}
-
 	response, err := c.HTTPClient.Do(request)
 	if err != nil {
 		return err
@@ -106,9 +98,6 @@ func (c *Client) request(v interface{}, path string, data interface{}) error {
 	if c.DebugLog != nil {
 		log.Printf("HTTP RESPONSE: %s", string(responseBody))
 	}
-
-	// TODO remove this
-	fmt.Printf("HTTP RESPONSE: %s\n", string(responseBody))
 
 	// Status code 500 is a server error and means nothing can be done at this
 	// point.

--- a/hlr.go
+++ b/hlr.go
@@ -26,8 +26,6 @@ type hlrRequest struct {
 }
 
 func requestDataForHLR(msisdn string, reference string) (*hlrRequest, error) {
-	request := &hlrRequest{}
-
 	if msisdn == "" {
 		return nil, errors.New("msisdn is required")
 	}
@@ -35,8 +33,10 @@ func requestDataForHLR(msisdn string, reference string) (*hlrRequest, error) {
 		return nil, errors.New("reference is required")
 	}
 
-	request.MSISDN = msisdn
-	request.Reference = reference
+	request := &hlrRequest{
+		MSISDN:    msisdn,
+		Reference: reference,
+	}
 
 	return request, nil
 }

--- a/hlr.go
+++ b/hlr.go
@@ -1,6 +1,9 @@
 package messagebird
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 // HLR stands for Home Location Register.
 // Contains information about the subscribers identity, telephone number, the associated services and general information about the location of the subscriber
@@ -15,4 +18,25 @@ type HLR struct {
 	CreatedDatetime *time.Time
 	StatusDatetime  *time.Time
 	Errors          []Error
+}
+
+type hlrRequest struct {
+	MSISDN    string `json:"msisdn"`
+	Reference string `json:"reference"`
+}
+
+func requestDataForHLR(msisdn string, reference string) (*hlrRequest, error) {
+	request := &hlrRequest{}
+
+	if msisdn == "" {
+		return nil, errors.New("msisdn is required")
+	}
+	if reference == "" {
+		return nil, errors.New("reference is required")
+	}
+
+	request.MSISDN = msisdn
+	request.Reference = reference
+
+	return request, nil
 }

--- a/hlr_test.go
+++ b/hlr_test.go
@@ -7,7 +7,7 @@ import (
 
 var hlrObject = []byte(`{
   "id":"27978c50354a93ca0ca8de6h54340177",
-  "href":"https:\/\/rest.messagebird.com\/hlr\/27978c50354a93ca0ca8de6h54340177",
+  "href":"https://rest.messagebird.com/hlr/27978c50354a93ca0ca8de6h54340177",
   "msisdn":31612345678,
   "network":20406,
   "reference":"MyReference",

--- a/hlr_test.go
+++ b/hlr_test.go
@@ -61,6 +61,20 @@ func TestHLR(t *testing.T) {
 	assertHLRObject(t, hlr)
 }
 
+func TestRequestDataForHLR(t *testing.T) {
+	requestData, err := requestDataForHLR("31612345678", "MyReference")
+	if err != nil {
+		t.Fatalf("Didn't expect an error while getting the request data for a HLR: %s", err)
+	}
+
+	if requestData.MSISDN != "31612345678" {
+		t.Errorf("Unexpected msisdn: %s, expected: 31612345678", requestData.MSISDN)
+	}
+	if requestData.Reference != "MyReference" {
+		t.Errorf("Unexpected reference: %s, expected: MyReference", requestData.Reference)
+	}
+}
+
 func TestNewHLR(t *testing.T) {
 	SetServerResponse(200, hlrObject)
 

--- a/lookup.go
+++ b/lookup.go
@@ -1,8 +1,6 @@
 package messagebird
 
-import (
-	"net/url"
-)
+import "net/url"
 
 // Formats represents phone number in multiple formats.
 type Formats struct {

--- a/lookup.go
+++ b/lookup.go
@@ -1,6 +1,8 @@
 package messagebird
 
-import "net/url"
+import (
+	"net/url"
+)
 
 // Formats represents phone number in multiple formats.
 type Formats struct {
@@ -25,6 +27,24 @@ type Lookup struct {
 type LookupParams struct {
 	CountryCode string
 	Reference   string
+}
+
+type lookupRequest struct {
+	CountryCode string `json:"countryCode,omitempty"`
+	Reference   string `json:"reference,omitempty"`
+}
+
+func requestDataForLookup(params *LookupParams) *lookupRequest {
+	request := &lookupRequest{}
+
+	if params == nil {
+		return request
+	}
+
+	request.CountryCode = params.CountryCode
+	request.Reference = params.Reference
+
+	return request
 }
 
 func paramsForLookup(params *LookupParams) *url.Values {

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -90,6 +90,21 @@ func TestLookupHLR(t *testing.T) {
 	checkHLR(t, hlr)
 }
 
+func TestRequestDataForLookupHLR(t *testing.T) {
+	lookupParams := &LookupParams{
+		CountryCode: "NL",
+		Reference:   "MyReference",
+	}
+	request := requestDataForLookup(lookupParams)
+
+	if request.CountryCode != "NL" {
+		t.Errorf("Unexpected country code: %s, expected: NL", request.CountryCode)
+	}
+	if request.Reference != "MyReference" {
+		t.Errorf("Unexpected reference: %s, expected: MyReference", request.Reference)
+	}
+}
+
 func TestNewLookupHLR(t *testing.T) {
 	SetServerResponse(201, lookupHLRObject)
 

--- a/message.go
+++ b/message.go
@@ -55,8 +55,6 @@ type messageRequest struct {
 }
 
 func requestDataForMessage(originator string, recipients []string, body string, params *MessageParams) (*messageRequest, error) {
-	request := &messageRequest{}
-
 	if originator == "" {
 		return nil, errors.New("originator is required")
 	}
@@ -66,9 +64,12 @@ func requestDataForMessage(originator string, recipients []string, body string, 
 	if body == "" {
 		return nil, errors.New("body is required")
 	}
-	request.Originator = originator
-	request.Recipients = recipients
-	request.Body = body
+
+	request := &messageRequest{
+		Originator: originator,
+		Recipients: recipients,
+		Body:       body,
+	}
 
 	if params == nil {
 		return request, nil

--- a/message.go
+++ b/message.go
@@ -2,8 +2,6 @@ package messagebird
 
 import (
 	"errors"
-	"net/url"
-	"strconv"
 	"time"
 )
 
@@ -42,47 +40,52 @@ type MessageParams struct {
 	ScheduledDatetime time.Time
 }
 
-// paramsForMessage converts the specified MessageParams struct to a
-// url.Values pointer and returns it.
-func paramsForMessage(params *MessageParams) (*url.Values, error) {
-	urlParams := &url.Values{}
+type messageRequest struct {
+	Originator        string      `json:"originator"`
+	Body              string      `json:"body"`
+	Recipients        []string    `json:"recipients"`
+	Type              string      `json:"type,omitempty"`
+	Reference         string      `json:"reference,omitempty"`
+	Validity          int         `json:"validity,omitempty"`
+	Gateway           int         `json:"gateway,omitempty"`
+	TypeDetails       TypeDetails `json:"typeDetails,omitempty"`
+	DataCoding        string      `json:"dataCoding,omitempty"`
+	MClass            int         `json:"mclass,omitempty"`
+	ScheduledDatetime string      `json:"scheduledDatetime,omitempty"`
+}
+
+func requestDataForMessage(originator string, recipients []string, body string, params *MessageParams) (*messageRequest, error) {
+	request := &messageRequest{}
+
+	if originator == "" {
+		return nil, errors.New("originator is required")
+	}
+	if len(recipients) == 0 {
+		return nil, errors.New("at least 1 recipient is required")
+	}
+	if body == "" {
+		return nil, errors.New("body is required")
+	}
+	request.Originator = originator
+	request.Recipients = recipients
+	request.Body = body
 
 	if params == nil {
-		return urlParams, nil
+		return request, nil
 	}
 
-	if params.Type != "" {
-		urlParams.Set("type", params.Type)
-		if params.Type == "flash" {
-			urlParams.Set("mclass", "0")
-		}
+	request.Type = params.Type
+	if request.Type == "flash" {
+		request.MClass = 0
+	} else {
+		request.MClass = 1
 	}
-	if params.Reference != "" {
-		urlParams.Set("reference", params.Reference)
-	}
-	if params.Validity != 0 {
-		urlParams.Set("validity", strconv.Itoa(params.Validity))
-	}
-	if params.Gateway != 0 {
-		urlParams.Set("gateway", strconv.Itoa(params.Gateway))
-	}
+	request.Reference = params.Reference
+	request.Validity = params.Validity
+	request.Gateway = params.Gateway
+	request.TypeDetails = params.TypeDetails
+	request.DataCoding = params.DataCoding
+	request.ScheduledDatetime = params.ScheduledDatetime.Format(time.RFC3339)
 
-	for k, v := range params.TypeDetails {
-		if vs, ok := v.(string); ok {
-			urlParams.Set("typeDetails["+k+"]", vs)
-		} else if vi, ok := v.(int); ok {
-			urlParams.Set("typeDetails["+k+"]", strconv.Itoa(vi))
-		} else {
-			return nil, errors.New("Unknown type for typeDetails value")
-		}
-	}
-
-	if params.DataCoding != "" {
-		urlParams.Set("datacoding", params.DataCoding)
-	}
-	if params.ScheduledDatetime.Unix() > 0 {
-		urlParams.Set("scheduledDatetime", params.ScheduledDatetime.Format(time.RFC3339))
-	}
-
-	return urlParams, nil
+	return request, nil
 }

--- a/message_test.go
+++ b/message_test.go
@@ -474,6 +474,15 @@ func TestRequestDataForMessage(t *testing.T) {
 		t.Fatalf("Didn't expect error while getting request data for message: %s", err)
 	}
 
+	if request.Originator != "MSGBIRD" {
+		t.Errorf("Unexpected originator: %s, expected: MSGBIRD", request.Originator)
+	}
+	if request.Recipients[0] != "31612345678" {
+		t.Errorf("Unexpected recipient: %s, expected: 31612345678", request.Recipients[0])
+	}
+	if request.Body != "MyBody" {
+		t.Errorf("Unexpected body: %s, expected: MyBody", request.Body)
+	}
 	if request.Type != messageParams.Type {
 		t.Errorf("Unexpected type: %s, expected: %s", request.Type, messageParams.Type)
 	}

--- a/message_test.go
+++ b/message_test.go
@@ -456,3 +456,44 @@ func TestNewMessageWithScheduledDatetime(t *testing.T) {
 		t.Errorf("Unexpected datetime status for message recipient: %s", message.Recipients.Items[0].StatusDatetime.Format(time.RFC3339))
 	}
 }
+
+func TestRequestDataForMessage(t *testing.T) {
+	currentTime := time.Now()
+	messageParams := &MessageParams{
+		Type:              "binary",
+		Reference:         "MyReference",
+		Validity:          1,
+		Gateway:           0,
+		TypeDetails:       nil,
+		DataCoding:        "unicode",
+		ScheduledDatetime: currentTime,
+	}
+
+	request, err := requestDataForMessage("MSGBIRD", []string{"31612345678"}, "MyBody", messageParams)
+	if err != nil {
+		t.Fatalf("Didn't expect error while getting request data for message: %s", err)
+	}
+
+	if request.Type != messageParams.Type {
+		t.Errorf("Unexpected type: %s, expected: %s", request.Type, messageParams.Type)
+	}
+	if request.Reference != messageParams.Reference {
+		t.Errorf("Unexpected reference: %s, expected: %s", request.Reference, messageParams.Reference)
+	}
+	if request.Validity != messageParams.Validity {
+		t.Errorf("Unexpected validity: %d, expected: %d", request.Validity, messageParams.Validity)
+	}
+	if request.Gateway != messageParams.Gateway {
+		t.Errorf("Unexpected gateway: %d, expected: %d", request.Gateway, messageParams.Gateway)
+	}
+	if request.TypeDetails != nil {
+		t.Errorf("Unexpected type details: %s, expected: nil", request.TypeDetails)
+	}
+	if request.DataCoding != messageParams.DataCoding {
+		t.Errorf("Unexpected data coding: %s, expected: %s", request.DataCoding, messageParams.DataCoding)
+	}
+	if request.ScheduledDatetime != messageParams.ScheduledDatetime.Format(time.RFC3339) {
+		t.Errorf("Unexepcted scheduled date time: %s, expected: %s", request.ScheduledDatetime, messageParams.ScheduledDatetime.Format(time.RFC3339))
+	}
+
+}

--- a/message_test.go
+++ b/message_test.go
@@ -7,7 +7,7 @@ import (
 
 var messageObject = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
-  "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
+  "href":"https://rest.messagebird.com/messages/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",
   "type":"sms",
   "originator":"TestName",
@@ -149,7 +149,7 @@ func TestNewMessageError(t *testing.T) {
 
 var messageWithParamsObject = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
-  "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
+  "href":"https://rest.messagebird.com/messages/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",
   "type":"sms",
   "originator":"TestName",
@@ -218,7 +218,7 @@ func TestNewMessageWithParams(t *testing.T) {
 
 var binaryMessageObject = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
-  "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
+  "href":"https://rest.messagebird.com/messages/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",
   "type":"binary",
   "originator":"TestName",
@@ -276,7 +276,7 @@ func TestNewMessageWithBinaryType(t *testing.T) {
 
 var premiumMessageObject = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
-  "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
+  "href":"https://rest.messagebird.com/messages/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",
   "type":"premium",
   "originator":"TestName",
@@ -344,7 +344,7 @@ func TestNewMessageWithPremiumType(t *testing.T) {
 
 var flashMessageObject = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
-  "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
+  "href":"https://rest.messagebird.com/messages/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",
   "type":"flash",
   "originator":"TestName",
@@ -391,7 +391,7 @@ func TestNewMessageWithFlashType(t *testing.T) {
 
 var messageObjectWithCreatedDatetime = []byte(`{
   "id":"6fe65f90454aa61536e6a88b88972670",
-  "href":"https:\/\/rest.messagebird.com\/messages\/6fe65f90454aa61536e6a88b88972670",
+  "href":"https://rest.messagebird.com/messages/6fe65f90454aa61536e6a88b88972670",
   "direction":"mt",
   "type":"sms",
   "originator":"TestName",

--- a/verify.go
+++ b/verify.go
@@ -1,8 +1,7 @@
 package messagebird
 
 import (
-	"net/url"
-	"strconv"
+	"errors"
 	"time"
 )
 
@@ -32,48 +31,40 @@ type VerifyParams struct {
 	TokenLength int
 }
 
-func paramsForVerify(params *VerifyParams) *url.Values {
-	urlParams := &url.Values{}
+type verifyRequest struct {
+	Recipient   string `json:"recipient"`
+	Originator  string `json:"originator,omitempty"`
+	Reference   string `json:"reference,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Template    string `json:"template,omitempty"`
+	DataCoding  string `json:"dataCoding,omitempty"`
+	Voice       string `json:"voice,omitempty"`
+	Language    string `json:"language,omitempty"`
+	Timeout     int    `json:"timeout,omitempty"`
+	TokenLength int    `json:"tokenLength,omitempty"`
+}
+
+func requestDataForVerify(recipient string, params *VerifyParams) (*verifyRequest, error) {
+	request := &verifyRequest{}
+
+	if recipient == "" {
+		return nil, errors.New("recipient is required")
+	}
+	request.Recipient = recipient
 
 	if params == nil {
-		return urlParams
+		return request, nil
 	}
 
-	if params.Originator != "" {
-		urlParams.Set("originator", params.Originator)
-	}
+	request.Originator = params.Originator
+	request.Reference = params.Reference
+	request.Type = params.Type
+	request.Template = params.Template
+	request.DataCoding = params.DataCoding
+	request.Voice = params.Voice
+	request.Language = params.Language
+	request.Timeout = params.Timeout
+	request.TokenLength = params.TokenLength
 
-	if params.Reference != "" {
-		urlParams.Set("reference", params.Reference)
-	}
-
-	if params.Type != "" {
-		urlParams.Set("type", params.Type)
-	}
-
-	if params.Template != "" {
-		urlParams.Set("template", params.Template)
-	}
-
-	if params.DataCoding != "" {
-		urlParams.Set("datacoding", params.DataCoding)
-	}
-
-	if params.Timeout != 0 {
-		urlParams.Set("timeout", strconv.Itoa(params.Timeout))
-	}
-
-	if params.TokenLength != 0 {
-		urlParams.Set("tokenLength", strconv.Itoa(params.TokenLength))
-	}
-
-	// Specific params for voice messages
-	if params.Language != "" {
-		urlParams.Set("language", params.Language)
-	}
-	if params.Voice != "" {
-		urlParams.Set("voice", params.Voice)
-	}
-
-	return urlParams
+	return request, nil
 }

--- a/verify.go
+++ b/verify.go
@@ -45,12 +45,13 @@ type verifyRequest struct {
 }
 
 func requestDataForVerify(recipient string, params *VerifyParams) (*verifyRequest, error) {
-	request := &verifyRequest{}
-
 	if recipient == "" {
 		return nil, errors.New("recipient is required")
 	}
-	request.Recipient = recipient
+
+	request := &verifyRequest{
+		Recipient: recipient,
+	}
 
 	if params == nil {
 		return request, nil

--- a/verify_test.go
+++ b/verify_test.go
@@ -135,5 +135,51 @@ func assertVerifyTokenObject(t *testing.T, v *Verify) {
 	if v.ValidUntilDatetime == nil || v.ValidUntilDatetime.Format(time.RFC3339) != "2017-05-30T12:40:20Z" {
 		t.Errorf("Unexpected Verify valid until datetime: %s", v.ValidUntilDatetime.Format(time.RFC3339))
 	}
+}
 
+func TestRequestDataForVerify(t *testing.T) {
+	verifyParams := &VerifyParams{
+		Originator:  "MSGBIRD",
+		Reference:   "MyReference",
+		Type:        "sms",
+		Template:    "Your code is: %token",
+		DataCoding:  "plain",
+		Voice:       "male",
+		Language:    "en-gb",
+		Timeout:     20,
+		TokenLength: 8,
+	}
+
+	requestData, err := requestDataForVerify("31612345678", verifyParams)
+	if err != nil {
+		t.Fatalf("Didn't expect error while getting request data for message: %s", err)
+	}
+
+	if requestData.Recipient != "31612345678" {
+		t.Errorf("Unexpected recipient: %s, expected: 31612345678", requestData.Recipient)
+	}
+	if requestData.Originator != "MSGBIRD" {
+		t.Errorf("Unexpected originator: %s, expected: MSGBIRD", requestData.Originator)
+	}
+	if requestData.Reference != "MyReference" {
+		t.Errorf("Unexpected reference: %s, expected: MyReference", requestData.Reference)
+	}
+	if requestData.Type != "sms" {
+		t.Errorf("Unexpected type: %s, expected: sms", requestData.Type)
+	}
+	if requestData.DataCoding != "plain" {
+		t.Errorf("Unexpected data coding: %s, expected: plain", requestData.DataCoding)
+	}
+	if requestData.Voice != "male" {
+		t.Errorf("Unexpected voice: %s, expected: male", requestData.Voice)
+	}
+	if requestData.Language != "en-gb" {
+		t.Errorf("Unexpected language: %s, expected en-gb", requestData.Language)
+	}
+	if requestData.Timeout != 20 {
+		t.Errorf("Unexepcted timeout: %d, expected 20", requestData.Timeout)
+	}
+	if requestData.TokenLength != 8 {
+		t.Errorf("Unexpected token length: %d, expected 8", requestData.TokenLength)
+	}
 }

--- a/voice_message.go
+++ b/voice_message.go
@@ -47,16 +47,17 @@ type voiceMessageRequest struct {
 }
 
 func requestDataForVoiceMessage(recipients []string, body string, params *VoiceMessageParams) (*voiceMessageRequest, error) {
-	request := &voiceMessageRequest{}
-
 	if len(recipients) == 0 {
 		return nil, errors.New("at least 1 recipient is required")
 	}
 	if body == "" {
 		return nil, errors.New("body is required")
 	}
-	request.Recipients = recipients
-	request.Body = body
+
+	request := &voiceMessageRequest{
+		Recipients: recipients,
+		Body:       body,
+	}
 
 	if params == nil {
 		return request, nil

--- a/voice_message_test.go
+++ b/voice_message_test.go
@@ -7,7 +7,7 @@ import (
 
 var voiceMessageObject = []byte(`{
   "id":"430c44a0354aab7ac9553f7a49907463",
-  "href":"https:\/\/rest.messagebird.com\/voicemessages\/430c44a0354aab7ac9553f7a49907463",
+  "href":"https://rest.messagebird.com/voicemessages/430c44a0354aab7ac9553f7a49907463",
   "originator":"MessageBird",
   "body":"Hello World",
   "reference":null,
@@ -111,7 +111,7 @@ func TestNewVoiceMessage(t *testing.T) {
 
 var voiceMessageObjectWithParams = []byte(`{
   "id":"430c44a0354aab7ac9553f7a49907463",
-  "href":"https:\/\/rest.messagebird.com\/voicemessages\/430c44a0354aab7ac9553f7a49907463",
+  "href":"https://rest.messagebird.com/voicemessages/430c44a0354aab7ac9553f7a49907463",
   "body":"Hello World",
   "reference":"MyReference",
   "language":"en-gb",
@@ -169,7 +169,7 @@ func TestNewVoiceMessageWithParams(t *testing.T) {
 
 var voiceMessageObjectWithCreatedDatetime = []byte(`{
   "id":"430c44a0354aab7ac9553f7a49907463",
-  "href":"https:\/\/rest.messagebird.com\/voicemessages\/430c44a0354aab7ac9553f7a49907463",
+  "href":"https://rest.messagebird.com/voicemessages/430c44a0354aab7ac9553f7a49907463",
   "body":"Hello World",
   "reference":null,
   "language":"en-gb",

--- a/voice_message_test.go
+++ b/voice_message_test.go
@@ -224,3 +224,43 @@ func TestNewVoiceMessageWithScheduledDatetime(t *testing.T) {
 		t.Errorf("Unexpected voice message recipient status: %s", message.Recipients.Items[0].Status)
 	}
 }
+
+func TestRequestDataForVoiceMessage(t *testing.T) {
+	currentTime := time.Now()
+	voiceParams := &VoiceMessageParams{
+		Originator:        "MSGBIRD",
+		Reference:         "MyReference",
+		Language:          "en-gb",
+		Voice:             "male",
+		Repeat:            2,
+		IfMachine:         "continue",
+		ScheduledDatetime: currentTime,
+	}
+
+	request, err := requestDataForVoiceMessage([]string{"31612345678"}, "MyBody", voiceParams)
+	if err != nil {
+		t.Fatalf("Didn't expect error while getting request data for voice message: %s", err)
+	}
+
+	if request.Recipients[0] != "31612345678" {
+		t.Errorf("Unexpected recipient: %s, expected: 31612345678", request.Recipients[0])
+	}
+	if request.Reference != "MyReference" {
+		t.Errorf("Unexpected reference: %s, expected: MyReference", request.Reference)
+	}
+	if request.Language != "en-gb" {
+		t.Errorf("Unexpected language: %s, expected: en-gb", request.Language)
+	}
+	if request.Voice != "male" {
+		t.Errorf("Unexpected voice: %s, expected: male", request.Voice)
+	}
+	if request.Repeat != 2 {
+		t.Errorf("Unexpected repeat: %d, expected: 2", request.Repeat)
+	}
+	if request.IfMachine != "continue" {
+		t.Errorf("Unexpected if machine: %s, expected: continue", request.IfMachine)
+	}
+	if request.ScheduledDatetime != voiceParams.ScheduledDatetime.Format(time.RFC3339) {
+		t.Errorf("Unexpected scheduled date time: %s, expected: %s", request.ScheduledDatetime, voiceParams.ScheduledDatetime.Format(time.RFC3339))
+	}
+}

--- a/voice_message_test.go
+++ b/voice_message_test.go
@@ -245,6 +245,9 @@ func TestRequestDataForVoiceMessage(t *testing.T) {
 	if request.Recipients[0] != "31612345678" {
 		t.Errorf("Unexpected recipient: %s, expected: 31612345678", request.Recipients[0])
 	}
+	if request.Body != "MyBody" {
+		t.Errorf("Unexpected body: %s, expected: MyBody", request.Body)
+	}
 	if request.Reference != "MyReference" {
 		t.Errorf("Unexpected reference: %s, expected: MyReference", request.Reference)
 	}


### PR DESCRIPTION
Only use JSON data when sending POST requests to the MessageBird API.