### PR TITLE
Fix unmarshal error for recipient on i386

### DIFF
--- a/recipient.go
+++ b/recipient.go
@@ -4,7 +4,7 @@ import "time"
 
 // Recipient struct holds information for a single msisdn with status details.
 type Recipient struct {
-	Recipient      int
+	Recipient      int64
 	Status         string
 	StatusDatetime *time.Time
 }


### PR DESCRIPTION
Most of the phone numbers (11 numbers) would throw an error during unmarshaling the response from the REST API, due to `int` would be only 32-bits long on i386 and 32-bits int is < 2,147,483,647 (10 numbers). This small fix would remove this inconvenience