### PR TITLE
Only format ScheduledDateTime if it has been set when generating message request data

### DIFF
--- a/message.go
+++ b/message.go
@@ -102,12 +102,16 @@ func requestDataForMessage(originator string, recipients []string, body string, 
 	} else {
 		request.MClass = 1
 	}
+
+	if params.ScheduledDatetime.IsZero() == false {
+		request.ScheduledDatetime = params.ScheduledDatetime.Format(time.RFC3339)
+	}
+
 	request.Reference = params.Reference
 	request.Validity = params.Validity
 	request.Gateway = params.Gateway
 	request.TypeDetails = params.TypeDetails
 	request.DataCoding = params.DataCoding
-	request.ScheduledDatetime = params.ScheduledDatetime.Format(time.RFC3339)
 
 	return request, nil
 }

--- a/message.go
+++ b/message.go
@@ -103,7 +103,7 @@ func requestDataForMessage(originator string, recipients []string, body string, 
 		request.MClass = 1
 	}
 
-	if params.ScheduledDatetime.IsZero() == false {
+	if !params.ScheduledDatetime.IsZero() {
 		request.ScheduledDatetime = params.ScheduledDatetime.Format(time.RFC3339)
 	}
 


### PR DESCRIPTION
When generating request data for a message, do not attempt to format the message param's ScheduledDateTime from message if it hasn't been set.