### PR TITLE
Fix 'datacoding' attribute error

### DIFF
--- a/message.go
+++ b/message.go
@@ -70,7 +70,7 @@ type messageRequest struct {
 	Validity          int         `json:"validity,omitempty"`
 	Gateway           int         `json:"gateway,omitempty"`
 	TypeDetails       TypeDetails `json:"typeDetails,omitempty"`
-	DataCoding        string      `json:"dataCoding,omitempty"`
+	DataCoding        string      `json:"datacoding,omitempty"`
 	MClass            int         `json:"mclass,omitempty"`
 	ScheduledDatetime string      `json:"scheduledDatetime,omitempty"`
 }


### PR DESCRIPTION
The datacoding used in SMS message is always 'plain' after I tried different values for DataCoding.
It looks like the json name for datacoding attribute is 'datacoding' rather than 'dataCoding'.