### PR TITLE
Bump minimum required Go version to 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: go
 
 go:
-  - 1.4
-  - tip
+  - 1.8
+  - stable
+  - master
+
+matrix:
+  allow_failures:
+    - go: master


### PR DESCRIPTION
- Also added an explicit requirement for Go stable.
- The Go master is allowed to fail, so it does not break the build in
  case of a broken version.