### PR TITLE
Various voice fixes and integration tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -68,7 +68,10 @@ func New(AccessKey string) *Client {
 
 // Request is for internal use only and unstable.
 func (c *Client) Request(v interface{}, method, path string, data interface{}) error {
-	uri, err := url.Parse(Endpoint + "/" + path)
+	if !strings.HasPrefix(path, "https://") && !strings.HasPrefix(path, "http://") {
+		path = fmt.Sprintf("%s/%s", Endpoint, path)
+	}
+	uri, err := url.Parse(path)
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -119,16 +120,19 @@ func (c *Client) Request(v interface{}, method, path string, data interface{}) e
 	if response.StatusCode == 500 {
 		return ErrUnexpectedResponse
 	}
-
-	if err = json.Unmarshal(responseBody, &v); err != nil {
-		return err
-	}
-
 	// Status codes 200 and 201 are indicative of being able to convert the
 	// response body to the struct that was specified.
 	if response.StatusCode == 200 || response.StatusCode == 201 {
+		if err := json.Unmarshal(responseBody, &v); err != nil {
+			return fmt.Errorf("could not decode response JSON, %s: %v", string(responseBody), err)
+		}
 		return nil
 	}
+
+	// We're dealing with an API error here. try to decode it, but don't do
+	// anything with the error. This is because not all values of `v` have
+	// `Error` properties and decoding could fail.
+	json.Unmarshal(responseBody, &v)
 
 	// Anything else than a 200/201/500 should be a JSON error.
 	return ErrResponse

--- a/voice/call.go
+++ b/voice/call.go
@@ -108,13 +108,13 @@ func (call *Call) UnmarshalJSON(data []byte) error {
 // An error is returned if no such call flow exists or is accessible.
 func CallByID(client *messagebird.Client, id string) (*Call, error) {
 	call := &Call{}
-	err := client.Request(call, http.MethodGet, "calls/"+id, nil)
+	err := client.Request(call, http.MethodGet, apiRoot+"/calls/"+id, nil)
 	return call, err
 }
 
 // Calls returns a Paginator which iterates over all Calls.
 func Calls(client *messagebird.Client) *Paginator {
-	return newPaginator(client, "calls/", reflect.TypeOf(Call{}))
+	return newPaginator(client, apiRoot+"/calls/", reflect.TypeOf(Call{}))
 }
 
 // InitiateCall initiates an outbound call.
@@ -141,7 +141,7 @@ func InitiateCall(client *messagebird.Client, source, destination string, callfl
 		body.Webhook.Token = webhook.Token
 	}
 	call := &Call{}
-	err := client.Request(call, http.MethodPost, "calls/", body)
+	err := client.Request(call, http.MethodPost, apiRoot+"/calls/", body)
 	return call, err
 }
 
@@ -149,10 +149,10 @@ func InitiateCall(client *messagebird.Client, source, destination string, callfl
 //
 // If the call is in progress, it hangs up all legs.
 func (call *Call) Delete(client *messagebird.Client) error {
-	return client.Request(nil, http.MethodDelete, "calls/"+call.ID, nil)
+	return client.Request(nil, http.MethodDelete, apiRoot+"/calls/"+call.ID, nil)
 }
 
 // Legs returns a paginator over all Legs associated with a call.
 func (call *Call) Legs(client *messagebird.Client) *Paginator {
-	return newPaginator(client, fmt.Sprintf("calls/%s/legs", call.ID), reflect.TypeOf(Leg{}))
+	return newPaginator(client, fmt.Sprintf("%s/calls/%s/legs", apiRoot, call.ID), reflect.TypeOf(Leg{}))
 }

--- a/voice/call.go
+++ b/voice/call.go
@@ -76,17 +76,17 @@ func (call *Call) UnmarshalJSON(data []byte) error {
 	}
 	createdAt, err := time.Parse(time.RFC3339, raw.CreatedAt)
 	if err != nil {
-		return fmt.Errorf("unable to parse CallFlow CreatedAt: %v", err)
+		return fmt.Errorf("unable to parse Call CreatedAt: %v", err)
 	}
 	updatedAt, err := time.Parse(time.RFC3339, raw.UpdatedAt)
 	if err != nil {
-		return fmt.Errorf("unable to parse CallFlow UpdatedAt: %v", err)
+		return fmt.Errorf("unable to parse Call UpdatedAt: %v", err)
 	}
 	var endedAt *time.Time
 	if raw.EndedAt != "" {
 		eat, err := time.Parse(time.RFC3339, raw.EndedAt)
 		if err != nil {
-			return fmt.Errorf("unable to parse CallFlow EndedAt: %v", err)
+			return fmt.Errorf("unable to parse Call EndedAt: %v", err)
 		}
 		endedAt = &eat
 	}

--- a/voice/call.go
+++ b/voice/call.go
@@ -107,9 +107,13 @@ func (call *Call) UnmarshalJSON(data []byte) error {
 //
 // An error is returned if no such call flow exists or is accessible.
 func CallByID(client *messagebird.Client, id string) (*Call, error) {
-	call := &Call{}
-	err := client.Request(call, http.MethodGet, apiRoot+"/calls/"+id, nil)
-	return call, err
+	var resp struct {
+		Data []Call `json:"data"`
+	}
+	if err := client.Request(&resp, http.MethodGet, apiRoot+"/calls/"+id, nil); err != nil {
+		return nil, err
+	}
+	return &resp.Data[0], nil
 }
 
 // Calls returns a Paginator which iterates over all Calls.

--- a/voice/call.go
+++ b/voice/call.go
@@ -140,9 +140,13 @@ func InitiateCall(client *messagebird.Client, source, destination string, callfl
 		body.Webhook.URL = webhook.URL
 		body.Webhook.Token = webhook.Token
 	}
-	call := &Call{}
-	err := client.Request(call, http.MethodPost, apiRoot+"/calls/", body)
-	return call, err
+	var resp struct {
+		Data []Call `json:"data"`
+	}
+	if err := client.Request(&resp, http.MethodPost, apiRoot+"/calls", body); err != nil {
+		return nil, err
+	}
+	return &resp.Data[0], nil
 }
 
 // Delete deletes the Call.

--- a/voice/call_test.go
+++ b/voice/call_test.go
@@ -31,3 +31,39 @@ func TestInitiateCall(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCallByID(t *testing.T) {
+	client, ok := testClient(t)
+	if !ok {
+		t.SkipNow()
+	}
+
+	source, destination := "31000000000", "31000000000"
+	callflow := CallFlow{
+		Title: "Say test",
+		Steps: []CallFlowStep{
+			&CallFlowSayStep{
+				Voice:    "male",
+				Payload:  "You are about to experience a great adventure which reaches from the inner mind to the outer limits",
+				Language: "en-US",
+			},
+			&CallFlowPauseStep{
+				Length: time.Second,
+			},
+			&CallFlowHangupStep{},
+		},
+	}
+	call, err := InitiateCall(client, source, destination, callflow, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second)
+	fetchedCall, err := CallByID(client, call.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fetchedCall.Source != call.Source {
+		t.Fatalf("mismatched source: exp %q, got %q", call.Source, fetchedCall.Source)
+	}
+}

--- a/voice/call_test.go
+++ b/voice/call_test.go
@@ -1,0 +1,33 @@
+package voice
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInitiateCall(t *testing.T) {
+	client, ok := testClient(t)
+	if !ok {
+		t.SkipNow()
+	}
+
+	source, destination := "31000000000", "31000000000"
+	callflow := CallFlow{
+		Title: "Say test",
+		Steps: []CallFlowStep{
+			&CallFlowSayStep{
+				Voice:    "male",
+				Payload:  "You are about to experience a great adventure which reaches from the inner mind to the outer limits",
+				Language: "en-US",
+			},
+			&CallFlowPauseStep{
+				Length: time.Second,
+			},
+			&CallFlowHangupStep{},
+		},
+	}
+	_, err := InitiateCall(client, source, destination, callflow, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/voice/callflow.go
+++ b/voice/callflow.go
@@ -106,13 +106,13 @@ func (callflow *CallFlow) UnmarshalJSON(data []byte) error {
 // An error is returned if no such call flow exists or is accessible.
 func CallFlowByID(client *messagebird.Client, id string) (*CallFlow, error) {
 	callflow := &CallFlow{}
-	err := client.Request(callflow, http.MethodGet, "call-flows/"+id, nil)
+	err := client.Request(callflow, http.MethodGet, apiRoot+"/call-flows/"+id, nil)
 	return callflow, err
 }
 
 // CallFlows returns a Paginator which iterates over all CallFlows.
 func CallFlows(client *messagebird.Client) *Paginator {
-	return newPaginator(client, "call-flows/", reflect.TypeOf(CallFlow{}))
+	return newPaginator(client, apiRoot+"/call-flows/", reflect.TypeOf(CallFlow{}))
 }
 
 // Create creates the callflow remotely.
@@ -122,7 +122,7 @@ func (callflow *CallFlow) Create(client *messagebird.Client) error {
 	var data struct {
 		Data []CallFlow `json:"data"`
 	}
-	if err := client.Request(&data, http.MethodPost, "call-flows/", callflow); err != nil {
+	if err := client.Request(&data, http.MethodPost, apiRoot+"/call-flows/", callflow); err != nil {
 		return err
 	}
 	*callflow = data.Data[0]
@@ -136,7 +136,7 @@ func (callflow *CallFlow) Update(client *messagebird.Client) error {
 	var data struct {
 		Data []CallFlow `json:"data"`
 	}
-	if err := client.Request(&data, http.MethodPut, "call-flows/"+callflow.ID, callflow); err != nil {
+	if err := client.Request(&data, http.MethodPut, apiRoot+"/call-flows/"+callflow.ID, callflow); err != nil {
 		return err
 	}
 	*callflow = data.Data[0]
@@ -145,7 +145,7 @@ func (callflow *CallFlow) Update(client *messagebird.Client) error {
 
 // Delete deletes the CallFlow.
 func (callflow *CallFlow) Delete(client *messagebird.Client) error {
-	return client.Request(nil, http.MethodDelete, "call-flows/"+callflow.ID, nil)
+	return client.Request(nil, http.MethodDelete, apiRoot+"/call-flows/"+callflow.ID, nil)
 }
 
 // A CallFlowStep is a single step that can be taken in a callflow.

--- a/voice/callflow.go
+++ b/voice/callflow.go
@@ -105,9 +105,13 @@ func (callflow *CallFlow) UnmarshalJSON(data []byte) error {
 //
 // An error is returned if no such call flow exists or is accessible.
 func CallFlowByID(client *messagebird.Client, id string) (*CallFlow, error) {
-	callflow := &CallFlow{}
-	err := client.Request(callflow, http.MethodGet, apiRoot+"/call-flows/"+id, nil)
-	return callflow, err
+	var data struct {
+		Data []CallFlow `json:"data"`
+	}
+	if err := client.Request(&data, http.MethodGet, apiRoot+"/call-flows/"+id, nil); err != nil {
+		return nil, err
+	}
+	return &data.Data[0], nil
 }
 
 // CallFlows returns a Paginator which iterates over all CallFlows.

--- a/voice/callflow_test.go
+++ b/voice/callflow_test.go
@@ -131,7 +131,7 @@ func TestCallFlowJSONUnmarshal(t *testing.T) {
 }
 
 func TestCreateCallFlow(t *testing.T) {
-	mbClient, stop := testClient(http.StatusOK, []byte(`{
+	mbClient, stop := testRequest(http.StatusOK, []byte(`{
 		"data": [
 			{
 				"id": "the-id",

--- a/voice/leg.go
+++ b/voice/leg.go
@@ -150,5 +150,5 @@ func (leg *Leg) UnmarshalJSON(data []byte) error {
 
 // Recordings retrieves the Recording objects associated with a leg.
 func (leg *Leg) Recordings(client *messagebird.Client) *Paginator {
-	return newPaginator(client, fmt.Sprintf("calls/%s/legs/%s/recordings", leg.CallID, leg.ID), reflect.TypeOf(Recording{}))
+	return newPaginator(client, fmt.Sprintf("%s/calls/%s/legs/%s/recordings", apiRoot, leg.CallID, leg.ID), reflect.TypeOf(Recording{}))
 }

--- a/voice/paginator_test.go
+++ b/voice/paginator_test.go
@@ -10,7 +10,7 @@ func TestPaginatorStream(t *testing.T) {
 	type myStruct struct {
 		Val int
 	}
-	mbClient, stop := testClient(http.StatusOK, []byte(`{
+	mbClient, stop := testRequest(http.StatusOK, []byte(`{
 		"data": [
 			{ "Val": 1 },
 			{ "Val": 2 },

--- a/voice/recording.go
+++ b/voice/recording.go
@@ -101,7 +101,7 @@ func (rec *Recording) Transcriptions(client *messagebird.Client) *Paginator {
 
 // DownloadFile streams the recorded WAV file.
 func (rec *Recording) DownloadFile(client *messagebird.Client) (io.ReadCloser, error) {
-	req, err := http.NewRequest(http.MethodGet, messagebird.Endpoint+rec.links["file"], nil)
+	req, err := http.NewRequest(http.MethodGet, apiRoot+rec.links["file"], nil)
 	if err != nil {
 		return nil, err
 	}

--- a/voice/recording_test.go
+++ b/voice/recording_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRecordingGetFile(t *testing.T) {
 	fileContents := []byte("this is not really a WAV file")
-	mbClient, stop := testClient(http.StatusOK, []byte(fileContents))
+	mbClient, stop := testRequest(http.StatusOK, []byte(fileContents))
 	defer stop()
 
 	rec := &Recording{

--- a/voice/transcription.go
+++ b/voice/transcription.go
@@ -72,7 +72,7 @@ func (trans *Transcription) UnmarshalJSON(data []byte) error {
 //
 // This is a plain text file.
 func (trans *Transcription) Contents(client *messagebird.Client) (string, error) {
-	req, err := http.NewRequest(http.MethodGet, messagebird.Endpoint+trans.links["file"], nil)
+	req, err := http.NewRequest(http.MethodGet, apiRoot+trans.links["file"], nil)
 	if err != nil {
 		return "", err
 	}

--- a/voice/transcription_test.go
+++ b/voice/transcription_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestTranscriptionGetContents(t *testing.T) {
 	text := "the quick brown fox jumps over the lazy dog"
-	mbClient, stop := testClient(http.StatusOK, []byte(text))
+	mbClient, stop := testRequest(http.StatusOK, []byte(text))
 	defer stop()
 
 	trans := &Transcription{

--- a/voice/voice.go
+++ b/voice/voice.go
@@ -1,0 +1,3 @@
+package voice
+
+const apiRoot = "https://voice.messagebird.com"

--- a/voice/webhook.go
+++ b/voice/webhook.go
@@ -66,7 +66,7 @@ func (wh *Webhook) UnmarshalJSON(data []byte) error {
 
 // Webhooks returns a paginator over all webhooks.
 func Webhooks(client *messagebird.Client) *Paginator {
-	return newPaginator(client, "webhooks/", reflect.TypeOf(Webhook{}))
+	return newPaginator(client, apiRoot+"/webhooks/", reflect.TypeOf(Webhook{}))
 }
 
 // CreateWebHook creates a new webhook the specified url that will be called
@@ -80,7 +80,7 @@ func CreateWebHook(client *messagebird.Client, url, token string) (*Webhook, err
 		Token: token,
 	}
 	wh := &Webhook{}
-	if err := client.Request(wh, http.MethodPost, "webhooks/", data); err != nil {
+	if err := client.Request(wh, http.MethodPost, apiRoot+"/webhooks/", data); err != nil {
 		return nil, err
 	}
 	return wh, nil
@@ -91,7 +91,7 @@ func (wh *Webhook) Update(client *messagebird.Client) error {
 	var data struct {
 		Data []Webhook `json:"data"`
 	}
-	if err := client.Request(&data, http.MethodPut, "webhooks/"+wh.ID, wh); err != nil {
+	if err := client.Request(&data, http.MethodPut, apiRoot+"/webhooks/"+wh.ID, wh); err != nil {
 		return err
 	}
 	*wh = data.Data[0]
@@ -100,5 +100,5 @@ func (wh *Webhook) Update(client *messagebird.Client) error {
 
 // Delete deletes a webhook.
 func (wh *Webhook) Delete(client *messagebird.Client) error {
-	return client.Request(nil, http.MethodDelete, "webhooks/"+wh.ID, nil)
+	return client.Request(nil, http.MethodDelete, apiRoot+"/webhooks/"+wh.ID, nil)
 }

--- a/voice/webhook.go
+++ b/voice/webhook.go
@@ -79,11 +79,13 @@ func CreateWebHook(client *messagebird.Client, url, token string) (*Webhook, err
 		URL:   url,
 		Token: token,
 	}
-	wh := &Webhook{}
-	if err := client.Request(wh, http.MethodPost, apiRoot+"/webhooks/", data); err != nil {
+	var resp struct {
+		Data []Webhook `json:"data"`
+	}
+	if err := client.Request(&resp, http.MethodPost, apiRoot+"/webhooks/", data); err != nil {
 		return nil, err
 	}
-	return wh, nil
+	return &resp.Data[0], nil
 }
 
 // Update syncs hte local state of a webhook to the MessageBird API.

--- a/voice/webhook_test.go
+++ b/voice/webhook_test.go
@@ -1,0 +1,45 @@
+package voice
+
+import (
+	"testing"
+)
+
+func TestCreateWebhook(t *testing.T) {
+	mbClient, ok := testClient(t)
+	if !ok {
+		t.SkipNow()
+	}
+
+	const url = "https://example.com/voice-webhook"
+	newWh, err := CreateWebHook(mbClient, url, "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newWh.URL != url {
+		t.Fatalf("Unexpected URL: %q", newWh.URL)
+	}
+}
+
+func TestWebhookList(t *testing.T) {
+	mbClient, ok := testClient(t)
+	if !ok {
+		t.SkipNow()
+	}
+
+	for _, c := range []string{"foo", "bar", "baz"} {
+		if _, err := CreateWebHook(mbClient, "https://example/com/"+c, "token"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	i := 0
+	for cf := range Webhooks(mbClient).Stream() {
+		if err, ok := cf.(error); ok {
+			t.Fatal(err)
+		}
+		i++
+	}
+	if i == 0 {
+		t.Fatal("no webhooks were fetched")
+	}
+}


### PR DESCRIPTION
This changeset introduces (optional) integration tests for the Voice API.

The approach uses a test key that can be set with the `MB_KEY_TEST` env var.