### PR TITLE
Deprecate ErrResponse error with ErrorResponse instance

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -5,5 +5,5 @@ type Balance struct {
 	Payment string
 	Type    string
 	Amount  float32
-	Errors  []Error
+	Errors  []Error // Deprecated: errors now returned at ErrorResponse instance as error.
 }

--- a/balance_test.go
+++ b/balance_test.go
@@ -35,21 +35,22 @@ func TestBalance(t *testing.T) {
 
 func TestBalanceError(t *testing.T) {
 	SetServerResponse(405, accessKeyErrorObject)
+	_, err := mbClient.Balance()
 
-	balance, err := mbClient.Balance()
-	if err != ErrResponse {
-		t.Fatalf("Expected ErrResponse to be returned, instead I got %s", err)
+	errorResponse, ok := err.(ErrorResponse)
+	if !ok {
+		t.Fatalf("Expected ErrorResponse to be returned, instead I got %s", err)
 	}
 
-	if len(balance.Errors) != 1 {
-		t.Fatalf("Unexpected number of errors: %d", len(balance.Errors))
+	if len(errorResponse.Errors) != 1 {
+		t.Fatalf("Unexpected number of errors: %d, expected: 1", len(errorResponse.Errors))
 	}
 
-	if balance.Errors[0].Code != 2 {
-		t.Errorf("Unexpected error code: %d", balance.Errors[0].Code)
+	if errorResponse.Errors[0].Code != 2 {
+		t.Errorf("Unexpected error code: %d, expected: 2", errorResponse.Errors[0].Code)
 	}
 
-	if balance.Errors[0].Parameter != "access_key" {
-		t.Errorf("Unexpected error parameter: %s", balance.Errors[0].Parameter)
+	if errorResponse.Errors[0].Parameter != "access_key" {
+		t.Errorf("Unexpected error parameter: %s, expected: access_key", errorResponse.Errors[0].Parameter)
 	}
 }

--- a/client.go
+++ b/client.go
@@ -47,8 +47,6 @@ const (
 	VerifyPath = "verify"
 	// LookupPath represents the path to the Lookup resource.
 	LookupPath = "lookup"
-
-	errorMessage = "The MessageBird API returned an error"
 )
 
 var (

--- a/client.go
+++ b/client.go
@@ -69,6 +69,10 @@ type Client struct {
 }
 
 // NewV2 creates a new MessageBird client object.
+// If the request to MessageBird API will return an
+// error, it will be returned as ErrorResponse instance
+// typed as the error, containing all codes,
+// descriptions and properies.
 func NewV2(accessKey string) *Client {
 	return &Client{
 		AccessKey: accessKey,
@@ -80,6 +84,8 @@ func NewV2(accessKey string) *Client {
 }
 
 // New creates a new MessageBird client object.
+// If the request to MessageBird API will return
+// and error, it will simply return ErrResponse.
 // Deprecated: use NewV2 until v2 release.
 func New(accessKey string) *Client {
 	return &Client{
@@ -89,16 +95,6 @@ func New(accessKey string) *Client {
 		},
 		request: requestV1,
 	}
-}
-
-// ErrorResponse represents errored API response.
-type ErrorResponse struct {
-	Errors []Error `json:"errors"`
-}
-
-// Error implements error interface.
-func (r ErrorResponse) Error() string {
-	return errorMessage
 }
 
 // Request is for internal use only and unstable.

--- a/client.go
+++ b/client.go
@@ -47,6 +47,8 @@ const (
 	VerifyPath = "verify"
 	// LookupPath represents the path to the Lookup resource.
 	LookupPath = "lookup"
+
+	errorMessage = "The MessageBird API returned an error"
 )
 
 var (
@@ -63,20 +65,48 @@ type Client struct {
 	AccessKey  string       // The API access key
 	HTTPClient *http.Client // The HTTP client to send requests on
 	DebugLog   *log.Logger  // Optional logger for debugging purposes
+	request    func(c *Client, v interface{}, method, path string, data interface{}) error
+}
+
+// NewV2 creates a new MessageBird client object.
+func NewV2(accessKey string) *Client {
+	return &Client{
+		AccessKey: accessKey,
+		HTTPClient: &http.Client{
+			Timeout: httpClientTimeout,
+		},
+		request: requestV2,
+	}
 }
 
 // New creates a new MessageBird client object.
+// Deprecated: use NewV2 until v2 release.
 func New(accessKey string) *Client {
 	return &Client{
 		AccessKey: accessKey,
 		HTTPClient: &http.Client{
 			Timeout: httpClientTimeout,
 		},
+		request: requestV1,
 	}
+}
+
+// ErrorResponse represents errored API response.
+type ErrorResponse struct {
+	Errors []Error `json:"errors"`
+}
+
+// Error implements error interface.
+func (r ErrorResponse) Error() string {
+	return errorMessage
 }
 
 // Request is for internal use only and unstable.
 func (c *Client) Request(v interface{}, method, path string, data interface{}) error {
+	return c.request(c, v, method, path, data)
+}
+
+func requestV1(c *Client, v interface{}, method, path string, data interface{}) error {
 	if !strings.HasPrefix(path, "https://") && !strings.HasPrefix(path, "http://") {
 		path = fmt.Sprintf("%s/%s", Endpoint, path)
 	}
@@ -148,6 +178,80 @@ func (c *Client) Request(v interface{}, method, path string, data interface{}) e
 
 	// Anything else than a 200/201/500 should be a JSON error.
 	return ErrResponse
+}
+
+func requestV2(c *Client, v interface{}, method, path string, data interface{}) error {
+	if !strings.HasPrefix(path, "https://") && !strings.HasPrefix(path, "http://") {
+		path = fmt.Sprintf("%s/%s", Endpoint, path)
+	}
+	uri, err := url.Parse(path)
+	if err != nil {
+		return err
+	}
+
+	var jsonEncoded []byte
+	if data != nil {
+		jsonEncoded, err = json.Marshal(data)
+		if err != nil {
+			return err
+		}
+	}
+
+	request, err := http.NewRequest(method, uri.String(), bytes.NewBuffer(jsonEncoded))
+	if err != nil {
+		return err
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "AccessKey "+c.AccessKey)
+	request.Header.Set("User-Agent", "MessageBird/ApiClient/"+ClientVersion+" Go/"+runtime.Version())
+
+	if c.DebugLog != nil {
+		if data != nil {
+			c.DebugLog.Printf("HTTP REQUEST: %s %s %s", method, uri.String(), jsonEncoded)
+		} else {
+			c.DebugLog.Printf("HTTP REQUEST: %s %s", method, uri.String())
+		}
+	}
+
+	response, err := c.HTTPClient.Do(request)
+	if err != nil {
+		return err
+	}
+
+	defer response.Body.Close()
+
+	responseBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	if c.DebugLog != nil {
+		c.DebugLog.Printf("HTTP RESPONSE: %s", string(responseBody))
+	}
+
+	// Status code 500 is a server error and means nothing can be done at this
+	// point.
+	if response.StatusCode == 500 {
+		return ErrUnexpectedResponse
+	}
+	// Status codes 200 and 201 are indicative of being able to convert the
+	// response body to the struct that was specified.
+	if response.StatusCode == 200 || response.StatusCode == 201 {
+		if err := json.Unmarshal(responseBody, &v); err != nil {
+			return fmt.Errorf("could not decode response JSON, %s: %v", string(responseBody), err)
+		}
+		return nil
+	}
+
+	// Anything else than a 200/201/500 should be a JSON error.
+	var errorResponse ErrorResponse
+	if err := json.Unmarshal(responseBody, &errorResponse); err != nil {
+		return err
+	}
+
+	return errorResponse
 }
 
 // Balance returns the balance information for the account that is associated
@@ -398,7 +502,6 @@ func (c *Client) Lookup(phoneNumber string, params *LookupParams) (*Lookup, erro
 		if err == ErrResponse {
 			return lookup, err
 		}
-
 		return nil, err
 	}
 

--- a/error.go
+++ b/error.go
@@ -1,8 +1,28 @@
 package messagebird
 
+import "fmt"
+
 // Error holds details including error code, human readable description and optional parameter that is related to the error.
 type Error struct {
 	Code        int
 	Description string
 	Parameter   string
+}
+
+// ErrorResponse represents errored API response.
+type ErrorResponse struct {
+	Errors []Error `json:"errors"`
+}
+
+// Error implements error interface.
+func (r ErrorResponse) Error() string {
+	eString := "API returned an error: "
+	for i, e := range r.Errors {
+		eString = eString + fmt.Sprintf("code: %d, description: %s, parameter: %s", e.Code, e.Description, e.Parameter)
+		if i < len(r.Errors)-1 {
+			eString = eString + ", "
+		}
+	}
+
+	return eString
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,48 @@
+package messagebird
+
+import "testing"
+
+func TestErrorResponseError(t *testing.T) {
+	tests := []struct {
+		name   string
+		errors []Error
+		expect string
+	}{
+		{
+			name: "single error",
+			errors: []Error{
+				Error{
+					Code:        2,
+					Description: "Request not allowed (incorrect access_key)",
+					Parameter:   "access_key",
+				},
+			},
+			expect: "API returned an error: code: 2, description: Request not allowed (incorrect access_key), parameter: access_key",
+		},
+		{
+			name: "multiple errors",
+			errors: []Error{
+				Error{
+					Code:        2,
+					Description: "Request not allowed (incorrect access_key)",
+					Parameter:   "access_key",
+				},
+				Error{
+					Code:        2,
+					Description: "Request not allowed (incorrect access_key)",
+					Parameter:   "access_key",
+				},
+			},
+			expect: "API returned an error: code: 2, description: Request not allowed (incorrect access_key), parameter: access_key, code: 2, description: Request not allowed (incorrect access_key), parameter: access_key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			er := ErrorResponse{tt.errors}
+			if er.Error() != tt.expect {
+				t.Errorf("expected error message to be:\n%s\ngot:\n%s", tt.expect, er.Error())
+			}
+		})
+	}
+}

--- a/hlr.go
+++ b/hlr.go
@@ -17,7 +17,7 @@ type HLR struct {
 	Details         map[string]interface{}
 	CreatedDatetime *time.Time
 	StatusDatetime  *time.Time
-	Errors          []Error
+	Errors          []Error // Deprecated: errors now returned at ErrorResponse instance as error.
 }
 
 // HLRList represents a list of HLR requests.

--- a/hlr_test.go
+++ b/hlr_test.go
@@ -124,22 +124,23 @@ func TestNewHLR(t *testing.T) {
 
 func TestHLRError(t *testing.T) {
 	SetServerResponse(http.StatusMethodNotAllowed, accessKeyErrorObject)
+	_, err := mbClient.HLR("dummy_hlr_id")
 
-	hlr, err := mbClient.HLR("dummy_hlr_id")
-	if err != ErrResponse {
-		t.Fatalf("Expected ErrResponse to be returned, instead I got %s", err)
+	errorResponse, ok := err.(ErrorResponse)
+	if !ok {
+		t.Fatalf("Expected ErrorResponse to be returned, instead I got %s", err)
 	}
 
-	if len(hlr.Errors) != 1 {
-		t.Fatalf("Unexpected number of errors: %d, expected: 1", len(hlr.Errors))
+	if len(errorResponse.Errors) != 1 {
+		t.Fatalf("Unexpected number of errors: %d, expected: 1", len(errorResponse.Errors))
 	}
 
-	if hlr.Errors[0].Code != 2 {
-		t.Errorf("Unexpected error code: %d, expected: 2", hlr.Errors[0].Code)
+	if errorResponse.Errors[0].Code != 2 {
+		t.Errorf("Unexpected error code: %d, expected: 2", errorResponse.Errors[0].Code)
 	}
 
-	if hlr.Errors[0].Parameter != "access_key" {
-		t.Errorf("Unexpected error parameter: %s, expected: access_key", hlr.Errors[0].Parameter)
+	if errorResponse.Errors[0].Parameter != "access_key" {
+		t.Errorf("Unexpected error parameter: %s, expected: access_key", errorResponse.Errors[0].Parameter)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -45,10 +45,8 @@ func startFauxServer() {
 		},
 	}
 
-	mbClient = &Client{
-		AccessKey:  "test_gshuPaZoeEG6ovbc8M79w0QyM",
-		HTTPClient: &http.Client{Transport: transport},
-	}
+	mbClient = NewV2("test_gshuPaZoeEG6ovbc8M79w0QyM")
+	mbClient.HTTPClient = &http.Client{Transport: transport}
 
 	if testing.Verbose() {
 		mbClient.DebugLog = log.New(os.Stdout, "DEBUG", log.Lshortfile)

--- a/message.go
+++ b/message.go
@@ -28,6 +28,7 @@ type Message struct {
 	ScheduledDatetime *time.Time
 	CreatedDatetime   *time.Time
 	Recipients        Recipients
+	Errors            []Error // Deprecated: errors now returned at ErrorResponse instance as error.
 }
 
 // MessageList represents a list of Messages.

--- a/message.go
+++ b/message.go
@@ -28,7 +28,6 @@ type Message struct {
 	ScheduledDatetime *time.Time
 	CreatedDatetime   *time.Time
 	Recipients        Recipients
-	Errors            []Error
 }
 
 // MessageList represents a list of Messages.

--- a/message_test.go
+++ b/message_test.go
@@ -114,10 +114,6 @@ func assertMessageObject(t *testing.T, message *Message) {
 	if message.Recipients.Items[0].StatusDatetime == nil || message.Recipients.Items[0].StatusDatetime.Format(time.RFC3339) != "2015-01-05T10:02:59Z" {
 		t.Errorf("Unexpected datetime status for message recipient: %s, expected: 2015-01-05T10:02:59Z", message.Recipients.Items[0].StatusDatetime.Format(time.RFC3339))
 	}
-
-	if len(message.Errors) != 0 {
-		t.Errorf("Unexpected number of errors in message: %d, expected: 0", len(message.Errors))
-	}
 }
 
 func TestNewMessage(t *testing.T) {
@@ -133,22 +129,23 @@ func TestNewMessage(t *testing.T) {
 
 func TestNewMessageError(t *testing.T) {
 	SetServerResponse(http.StatusMethodNotAllowed, accessKeyErrorObject)
+	_, err := mbClient.NewMessage("TestName", []string{"31612345678"}, "Hello World", nil)
 
-	message, err := mbClient.NewMessage("TestName", []string{"31612345678"}, "Hello World", nil)
-	if err != ErrResponse {
-		t.Fatalf("Expected ErrResponse to be returned, instead I got %s", err)
+	errorResponse, ok := err.(ErrorResponse)
+	if !ok {
+		t.Fatalf("Expected ErrorResponse to be returned, instead I got %s", err)
 	}
 
-	if len(message.Errors) != 1 {
-		t.Fatalf("Unexpected number of errors: %d, expected: 1", len(message.Errors))
+	if len(errorResponse.Errors) != 1 {
+		t.Fatalf("Unexpected number of errors: %d, expected: 1", len(errorResponse.Errors))
 	}
 
-	if message.Errors[0].Code != 2 {
-		t.Errorf("Unexpected error code: %d, expected: 2", message.Errors[0].Code)
+	if errorResponse.Errors[0].Code != 2 {
+		t.Errorf("Unexpected error code: %d, expected: 2", errorResponse.Errors[0].Code)
 	}
 
-	if message.Errors[0].Parameter != "access_key" {
-		t.Errorf("Unexpected error parameter: %s, expected: access_key", message.Errors[0].Parameter)
+	if errorResponse.Errors[0].Parameter != "access_key" {
+		t.Errorf("Unexpected error parameter: %s, expected: access_key", errorResponse.Errors[0].Parameter)
 	}
 }
 

--- a/mms_message.go
+++ b/mms_message.go
@@ -20,7 +20,7 @@ type MMSMessage struct {
 	ScheduledDatetime *time.Time
 	CreatedDatetime   *time.Time
 	Recipients        Recipients
-	Errors            []Error
+	Errors            []Error // Deprecated: errors now returned at ErrorResponse instance as error
 }
 
 // MMSMessageParams represents the parameters that can be supplied when creating

--- a/mms_message_test.go
+++ b/mms_message_test.go
@@ -109,19 +109,23 @@ func TestNewMMSMessageError(t *testing.T) {
 		Reference:         "",
 		ScheduledDatetime: time.Now(),
 	}
-	mmsMessage, err := mbClient.NewMMSMessage("TestName", []string{"31612345678"}, params)
+	_, err := mbClient.NewMMSMessage("TestName", []string{"31612345678"}, params)
 
-	if err != ErrResponse {
-		t.Fatalf("Expected ErrResponse to be returned, instead I got %s", err)
+	errorResponse, ok := err.(ErrorResponse)
+	if !ok {
+		t.Fatalf("Expected ErrorResponse to be returned, instead I got %s", err)
 	}
-	if len(mmsMessage.Errors) != 1 {
-		t.Fatalf("Unexpected number of errors: %d", len(mmsMessage.Errors))
+
+	if len(errorResponse.Errors) != 1 {
+		t.Fatalf("Unexpected number of errors: %d, expected: 1", len(errorResponse.Errors))
 	}
-	if mmsMessage.Errors[0].Code != 2 {
-		t.Errorf("Unexpected error code: %d", mmsMessage.Errors[0].Code)
+
+	if errorResponse.Errors[0].Code != 2 {
+		t.Errorf("Unexpected error code: %d, expected: 2", errorResponse.Errors[0].Code)
 	}
-	if mmsMessage.Errors[0].Parameter != "access_key" {
-		t.Errorf("Unexpected error parameter %s", mmsMessage.Errors[0].Parameter)
+
+	if errorResponse.Errors[0].Parameter != "access_key" {
+		t.Errorf("Unexpected error parameter: %s, expected: access_key", errorResponse.Errors[0].Parameter)
 	}
 }
 

--- a/verify.go
+++ b/verify.go
@@ -15,7 +15,7 @@ type Verify struct {
 	CreatedDatetime    *time.Time
 	ValidUntilDatetime *time.Time
 	Recipient          int
-	Errors             []Error
+	Errors             []Error // Deprecated: errors now returned at ErrorResponse instance as error.
 }
 
 // VerifyParams handles optional verification parameters.

--- a/voice/main_test.go
+++ b/voice/main_test.go
@@ -24,10 +24,9 @@ func testRequest(status int, body []byte) (*messagebird.Client, func()) {
 			return tls.Dial(netw, addr, &tls.Config{InsecureSkipVerify: true})
 		},
 	}
-	mbClient := &messagebird.Client{
-		AccessKey:  "test_gshuPaZoeEG6ovbc8M79w0QyM",
-		HTTPClient: &http.Client{Transport: transport},
-	}
+	mbClient := messagebird.NewV2("test_gshuPaZoeEG6ovbc8M79w0QyM")
+	mbClient.HTTPClient = &http.Client{Transport: transport}
+
 	if testing.Verbose() {
 		mbClient.DebugLog = log.New(os.Stdout, "DEBUG", log.Lshortfile)
 	}

--- a/voice_message.go
+++ b/voice_message.go
@@ -20,7 +20,7 @@ type VoiceMessage struct {
 	ScheduledDatetime *time.Time
 	CreatedDatetime   *time.Time
 	Recipients        Recipients
-	Errors            []Error
+	Errors            []Error // Deprecated: errors now returned at ErrorResponse instance as error.
 }
 
 // VoiceMessageList represents a list of VoiceMessages.


### PR DESCRIPTION
Should the tests for `New` factory be duplicated? As the tests now runnig under `NewV2` factory.
https://github.com/messagebird/go-rest-api/issues/34