### PR TITLE
Fixed failing calls to Lookup

### DIFF
--- a/client.go
+++ b/client.go
@@ -492,7 +492,7 @@ func (c *Client) Lookup(phoneNumber string, params *LookupParams) (*Lookup, erro
 	path := LookupPath + "/" + phoneNumber + "?" + urlParams.Encode()
 
 	lookup := &Lookup{}
-	if err := c.Request(lookup, http.MethodPost, path, nil); err != nil {
+	if err := c.Request(lookup, http.MethodGet, path, nil); err != nil {
 		if err == ErrResponse {
 			return lookup, err
 		}


### PR DESCRIPTION
Hi,

I am currently completing the programming assignment for the go job but was having no luck with calling the Lookup method. 

The only error I was getting back from the package was 
"2018/07/07 13:51:57 invalid character 'M' looking for beginning of value"

This turned out to be caused by the package doing a POST when the API wants a GET.

Thanks,