### PR TITLE
Fix error: lookup uses GET

### DIFF
--- a/lookup/lookup.go
+++ b/lookup/lookup.go
@@ -44,13 +44,13 @@ const hlrPath = "hlr"
 // lookupPath represents the path to the Lookup resource.
 const lookupPath = "lookup"
 
-// Create performs a new lookup for the specified number.
-func Create(c *messagebird.Client, phoneNumber string, params *Params) (*Lookup, error) {
+// Read performs a new lookup for the specified number.
+func Read(c *messagebird.Client, phoneNumber string, params *Params) (*Lookup, error) {
 	urlParams := paramsForLookup(params)
 	path := lookupPath + "/" + phoneNumber + "?" + urlParams.Encode()
 
 	lookup := &Lookup{}
-	if err := c.Request(lookup, http.MethodPost, path, nil); err != nil {
+	if err := c.Request(lookup, http.MethodGet, path, nil); err != nil {
 		return nil, err
 	}
 

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -13,12 +13,12 @@ func TestMain(m *testing.M) {
 	mbtest.EnableServer(m)
 }
 
-func TestCreate(t *testing.T) {
+func TestRead(t *testing.T) {
 	mbtest.WillReturnTestdata(t, "lookupObject.json", http.StatusOK)
 	client := mbtest.Client(t)
 
 	phoneNumber := "31624971134"
-	lookup, err := Create(client, phoneNumber, &Params{CountryCode: "NL"})
+	lookup, err := Read(client, phoneNumber, &Params{CountryCode: "NL"})
 	if err != nil {
 		t.Fatalf("Didn't expect error while doing the lookup: %s", err)
 	}


### PR DESCRIPTION
Lookup uses GET, not POST - see [docs](https://developers.messagebird.com/docs/lookup#request-a-lookup).