### PR TITLE
Fix query

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// ClientVersion is used in User-Agent request header to provide server with API level.
-	ClientVersion = "5.0.0"
+	ClientVersion = "5.0.1"
 
 	// Endpoint points you to MessageBird REST API.
 	Endpoint = "https://rest.messagebird.com"

--- a/client.go
+++ b/client.go
@@ -85,10 +85,12 @@ func (c *Client) Request(v interface{}, method, path string, data interface{}) e
 		return err
 	}
 
-	request.Header.Set("Content-Type", string(contentType))
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Authorization", "AccessKey "+c.AccessKey)
 	request.Header.Set("User-Agent", "MessageBird/ApiClient/"+ClientVersion+" Go/"+runtime.Version())
+	if contentType != contentTypeEmpty {
+		request.Header.Set("Content-Type", string(contentType))
+	}
 
 	if c.DebugLog != nil {
 		if data != nil {

--- a/client.go
+++ b/client.go
@@ -147,20 +147,18 @@ func (c *Client) Request(v interface{}, method, path string, data interface{}) e
 // prepareRequestBody takes untyped data and attempts constructing a meaningful
 // request body from it. It also returns the appropriate Content-Type.
 func prepareRequestBody(data interface{}) ([]byte, contentType, error) {
-	// Nil bodies are accepted by `net/http`, so this is not an error.
-	if data == nil {
+	switch data := data.(type) {
+	case nil:
+		// Nil bodies are accepted by `net/http`, so this is not an error.
 		return nil, contentTypeEmpty, nil
-	}
+	case string:
+		return []byte(data), contentTypeFormURLEncoded, nil
+	default:
+		b, err := json.Marshal(data)
+		if err != nil {
+			return nil, contentType(""), err
+		}
 
-	s, ok := data.(string)
-	if ok {
-		return []byte(s), contentTypeFormURLEncoded, nil
+		return b, contentTypeJSON, nil
 	}
-
-	b, err := json.Marshal(data)
-	if err != nil {
-		return nil, contentType(""), err
-	}
-
-	return b, contentTypeJSON, nil
 }

--- a/group/group_test.go
+++ b/group/group_test.go
@@ -159,6 +159,10 @@ func TestUpdate(t *testing.T) {
 
 	mbtest.AssertEndpointCalled(t, http.MethodPatch, "/groups/group-id")
 	mbtest.AssertTestdata(t, "groupRequestUpdateObject.json", mbtest.Request.Body)
+
+	if mbtest.Request.ContentType != "application/json" {
+		t.Fatalf("got %s, expected application/json", mbtest.Request.ContentType)
+	}
 }
 
 func TestAddContacts(t *testing.T) {

--- a/group/group_test.go
+++ b/group/group_test.go
@@ -169,10 +169,11 @@ func TestAddContacts(t *testing.T) {
 		t.Fatalf("unexpected error removing Contacts from Group: %s", err)
 	}
 
-	mbtest.AssertEndpointCalled(t, http.MethodGet, "/groups/group-id/contacts")
+	mbtest.AssertEndpointCalled(t, http.MethodPut, "/groups/group-id/contacts")
+	mbtest.AssertTestdata(t, "groupRequestAddContactsObject.txt", mbtest.Request.Body)
 
-	if mbtest.Request.URL.RawQuery != "_method=PUT&ids[]=first-contact-id&ids[]=second-contact-id" {
-		t.Fatalf("got %s, expected _method=PUT&ids[]=first-contact-id&ids[]=second-contact-id", mbtest.Request.URL.RawQuery)
+	if mbtest.Request.ContentType != "application/x-www-form-urlencoded" {
+		t.Fatalf("got %s, expected application/x-www-form-urlencoded", mbtest.Request.ContentType)
 	}
 }
 

--- a/group/testdata/groupRequestAddContactsObject.txt
+++ b/group/testdata/groupRequestAddContactsObject.txt
@@ -1,0 +1,1 @@
+ids[]=first-contact-id&ids[]=second-contact-id

--- a/internal/mbtest/test_server.go
+++ b/internal/mbtest/test_server.go
@@ -10,9 +10,9 @@ import (
 )
 
 type request struct {
-	Body   []byte
-	Method string
-	URL    *url.URL
+	Body                []byte
+	ContentType, Method string
+	URL                 *url.URL
 }
 
 // Request contains the lastly received http.Request by the fake server.
@@ -35,8 +35,9 @@ func EnableServer(m *testing.M) {
 func initAndStartServer() {
 	server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		Request = request{
-			Method: r.Method,
-			URL:    r.URL,
+			ContentType: r.Header.Get("Content-Type"),
+			Method:      r.Method,
+			URL:         r.URL,
 		}
 
 		var err error


### PR DESCRIPTION
Adding contacts to a group requires a PUT request to the `/groups/{groupId}/contacts` [endpoint](https://developers.messagebird.com/docs/groups#add-contact-to-group), with content type `x-www-form-urlencoded` and a body in this format:

```
ids[]=contact-id&ids[]=other-contact-id
```

---

`messagebird.Client.Request()` marshals all request data to JSON by default though.
Our current implementation uses the [alternative way](https://developers.messagebird.com/docs/alternatives) of sending requests, a GET request with the `_method=PUT` param set, to solve this problem. This allowed us to provide the contact IDs as a query string to bypass the default JSON marshalling.

It worked nicely before, but on August 21st a [PR](https://go-review.googlesource.com/c/go/+/99135) was merged into Go' master. All `url.URL` queries are now forced to be properly encoded, which breaks our previous implementation: we end up with gibberish when attempting to encode `ids[]=foo&ids[]=bar` .

---

This PR fixes the problem by using the "real" way of making requests - a `PUT`.