### PR TITLE
implemented onFinish attribute for CallFlowRecordStep

### DIFF
--- a/voice/callflow.go
+++ b/voice/callflow.go
@@ -440,6 +440,18 @@ type CallFlowRecordStep struct {
 	// Allowed values: de-DE, en-AU, en-UK, en-US, es-ES, es-LA, fr-FR, it-IT, nl-NL, pt-BR.
 	TranscribeLanguage string
 
+	// (Optional) OnFinish contains the URL to get a new CallFlow from when the recording terminates and this CallFlowRecordStep ends.
+	//
+	// The URL must contain a schema e.g. http://... or https://...
+	// This attribute is used for chaining call flows. When the current step ends,
+	// a POST request containing information about the recording is sent to the URL specified.
+	// This gets a new callflow from the URL specified, but re-uses the original Call ID and Leg ID i.e. it's the same Call.
+	//
+	// To get at the recording information from the POST request body, you must call (instead of relying on req.Form):
+	// ```go
+	// body,_ := ioutil.ReadAll(req.Body)
+	// recordingInfo := string(body[:])
+	// ```
 	OnFinish string
 }
 
@@ -451,7 +463,7 @@ type jsonCallFlowRecordStep struct {
 		Timeout            int    `json:"timeout"`
 		FinishOnKey        string `json:"finishOnKey"`
 		TranscribeLanguage string `json:"transcribeLanguage"`
-		OnFinish string `json:"onFinish"`
+		OnFinish           string `json:"onFinish"`
 	} `json:"options"`
 }
 
@@ -480,7 +492,7 @@ func (step *CallFlowRecordStep) UnmarshalJSON(data []byte) error {
 		Timeout:            time.Duration(raw.Options.Timeout) * time.Second,
 		FinishOnKey:        raw.Options.FinishOnKey,
 		TranscribeLanguage: raw.Options.TranscribeLanguage,
-		OnFinish: raw.Options.OnFinish,
+		OnFinish:           raw.Options.OnFinish,
 	}
 	return nil
 }

--- a/voice/callflow.go
+++ b/voice/callflow.go
@@ -439,6 +439,8 @@ type CallFlowRecordStep struct {
 	//
 	// Allowed values: de-DE, en-AU, en-UK, en-US, es-ES, es-LA, fr-FR, it-IT, nl-NL, pt-BR.
 	TranscribeLanguage string
+
+	OnFinish string
 }
 
 type jsonCallFlowRecordStep struct {
@@ -449,6 +451,7 @@ type jsonCallFlowRecordStep struct {
 		Timeout            int    `json:"timeout"`
 		FinishOnKey        string `json:"finishOnKey"`
 		TranscribeLanguage string `json:"transcribeLanguage"`
+		OnFinish string `json:"onFinish"`
 	} `json:"options"`
 }
 
@@ -461,6 +464,7 @@ func (step *CallFlowRecordStep) MarshalJSON() ([]byte, error) {
 	data.Options.Timeout = int(step.Timeout / time.Second)
 	data.Options.FinishOnKey = step.FinishOnKey
 	data.Options.TranscribeLanguage = step.TranscribeLanguage
+	data.Options.OnFinish = step.OnFinish
 	return json.Marshal(data)
 }
 
@@ -476,6 +480,7 @@ func (step *CallFlowRecordStep) UnmarshalJSON(data []byte) error {
 		Timeout:            time.Duration(raw.Options.Timeout) * time.Second,
 		FinishOnKey:        raw.Options.FinishOnKey,
 		TranscribeLanguage: raw.Options.TranscribeLanguage,
+		OnFinish: raw.Options.OnFinish,
 	}
 	return nil
 }


### PR DESCRIPTION
Implemented `onFinish` attribute for `step[].options` (https://developers.messagebird.com/docs/voice-calling#call-flows) as

```go
CallFlowRecordStep struct{
  // ...
  OnFinish string
}
```

This is required for chaining call flows while staying on the same callID/legID. A specific example would be how `onFinish` is used here: https://github.com/messagebirdguides/automated-surveys