### PR TITLE
Add URL parameter to Client for testing with MessageBird mock

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,6 +45,7 @@ type Client struct {
 	AccessKey  string       // The API access key
 	HTTPClient *http.Client // The HTTP client to send requests on
 	DebugLog   *log.Logger  // Optional logger for debugging purposes
+	URL        string       // Use for tests with MessageBird mock
 }
 
 type contentType string
@@ -68,7 +69,11 @@ func New(accessKey string) *Client {
 // Request is for internal use only and unstable.
 func (c *Client) Request(v interface{}, method, path string, data interface{}) error {
 	if !strings.HasPrefix(path, "https://") && !strings.HasPrefix(path, "http://") {
-		path = fmt.Sprintf("%s/%s", Endpoint, path)
+		endpoint := Endpoint
+		if c.URL != "" {
+			endpoint = c.URL
+		}
+		path = fmt.Sprintf("%s/%s", endpoint, path)
 	}
 	uri, err := url.Parse(path)
 	if err != nil {


### PR DESCRIPTION
Hello guys!

I use MessageBird in my project and for automatic tests I need to change the endpoint to send requests from standard url `https://rest.messagebird.com` to `localhost:8080` with the running MessageBird mock (simple server handling same endpoints and saving requests for later checking). To do this, I need to replace the URL and this can not be done at this time, since I do not want to test MessageBird itself, I want to test the work of my backend code, correct requests, correct data in requests.
Therefore, I suggest adding the URL parameter to the client, if it is specified, then it will be used instead of the usual Endpoint.

I am glad to hear your comments and suggestions