### PR TITLE
Fixes for transcriptions

### DIFF
--- a/voice/callflow.go
+++ b/voice/callflow.go
@@ -434,6 +434,10 @@ type CallFlowRecordStep struct {
 	// Values allowed are: "any", "#", "*", "none" (default).
 	FinishOnKey string
 
+	//If you want to have a transcription of a recording, after the recording has finished.
+	// It is used when steps[].action is record and it is optional with the default value being false.
+	Transcribe bool
+
 	// Set this to get a transcription of a recording in the specified language
 	// after the recording has finished.
 	//
@@ -448,6 +452,7 @@ type jsonCallFlowRecordStep struct {
 		MaxLength          int    `json:"maxLength"`
 		Timeout            int    `json:"timeout"`
 		FinishOnKey        string `json:"finishOnKey"`
+		Transcribe         bool   `json:"transcribe"`
 		TranscribeLanguage string `json:"transcribeLanguage"`
 	} `json:"options"`
 }
@@ -457,9 +462,10 @@ func (step *CallFlowRecordStep) MarshalJSON() ([]byte, error) {
 	data := jsonCallFlowRecordStep{}
 	data.CallFlowStepBase = step.CallFlowStepBase
 	data.Action = "record"
-	data.Options.MaxLength = int(step.MaxLength / time.Second)
-	data.Options.Timeout = int(step.Timeout / time.Second)
+	data.Options.MaxLength = int(step.MaxLength.Nanoseconds())
+	data.Options.Timeout = int(step.Timeout.Nanoseconds())
 	data.Options.FinishOnKey = step.FinishOnKey
+	data.Options.Transcribe = step.Transcribe
 	data.Options.TranscribeLanguage = step.TranscribeLanguage
 	return json.Marshal(data)
 }
@@ -472,9 +478,10 @@ func (step *CallFlowRecordStep) UnmarshalJSON(data []byte) error {
 	}
 	*step = CallFlowRecordStep{
 		CallFlowStepBase:   raw.CallFlowStepBase,
-		MaxLength:          time.Duration(raw.Options.MaxLength) * time.Second,
-		Timeout:            time.Duration(raw.Options.Timeout) * time.Second,
+		MaxLength:          time.Duration(raw.Options.MaxLength),
+		Timeout:            time.Duration(raw.Options.Timeout),
 		FinishOnKey:        raw.Options.FinishOnKey,
+		Transcribe:         raw.Options.Transcribe,
 		TranscribeLanguage: raw.Options.TranscribeLanguage,
 	}
 	return nil

--- a/voice/callflow_test.go
+++ b/voice/callflow_test.go
@@ -22,6 +22,14 @@ func ExampleCallFlow() {
 			&CallFlowTransferStep{
 				Destination: "31600000000",
 			},
+			&CallFlowRecordStep{
+				CallFlowStepBase:   CallFlowStepBase{},
+				MaxLength:          10,
+				Timeout:            5,
+				FinishOnKey:        "#",
+				Transcribe:         true,
+				TranscribeLanguage: "en-US",
+			},
 		},
 	}
 	_ = callflow
@@ -47,6 +55,16 @@ func TestCallFlowJSONMarshal(t *testing.T) {
 					ID: "2",
 				},
 				Length: time.Second * 10,
+			},
+			&CallFlowRecordStep{
+				CallFlowStepBase:   CallFlowStepBase{
+					ID: "3",
+				},
+				MaxLength:          10,
+				Timeout:            5,
+				FinishOnKey:        "#",
+				Transcribe:         true,
+				TranscribeLanguage: "en-US",
 			},
 		},
 		CreatedAt: refCreatedAt,
@@ -88,6 +106,17 @@ func TestCallFlowJSONUnmarshal(t *testing.T) {
 				 "options": {
 					 "length": 10
 				 }
+			 },
+			 {
+				"id": "3",
+				"action": "record",
+				"options": {
+					"maxLength": 10,
+					"timeout": 5,
+					"finishOnKey": "#",
+					"transcribe": true,
+					"transcribeLanguage": "en-US"
+				}
 			 }
 		 ],
 		 "createdAt": "2018-01-29T13:46:06Z",
@@ -112,6 +141,16 @@ func TestCallFlowJSONUnmarshal(t *testing.T) {
 					ID: "2",
 				},
 				Length: time.Second * 10,
+			},
+			&CallFlowRecordStep{
+				CallFlowStepBase:   CallFlowStepBase{
+					ID: "3",
+				},
+				MaxLength:          10,
+				Timeout:            5,
+				FinishOnKey:        "#",
+				Transcribe:         true,
+				TranscribeLanguage: "en-US",
 			},
 		},
 		CreatedAt: refCreatedAt,
@@ -146,6 +185,16 @@ func TestCreateCallFlow(t *testing.T) {
 			&CallFlowPauseStep{
 				Length: time.Second,
 			},
+			&CallFlowRecordStep{
+				CallFlowStepBase:   CallFlowStepBase{
+					ID: "3",
+				},
+				MaxLength:          10,
+				Timeout:            5,
+				FinishOnKey:        "#",
+				Transcribe:         true,
+				TranscribeLanguage: "en-US",
+			},
 		},
 	}
 	if err := newCf.Create(mbClient); err != nil {
@@ -154,8 +203,8 @@ func TestCreateCallFlow(t *testing.T) {
 	if newCf.Title != "the-title" {
 		t.Fatalf("Unexpected Title: %q", newCf.Title)
 	}
-	if len(newCf.Steps) != 2 {
-		t.Fatalf("Unexpected Title: %q", newCf.Title)
+	if len(newCf.Steps) != 3 {
+		t.Fatalf("Unexpected number of steps: %q", len(newCf.Steps))
 	}
 }
 

--- a/voice/recording.go
+++ b/voice/recording.go
@@ -94,8 +94,8 @@ func (rec *Recording) UnmarshalJSON(data []byte) error {
 }
 
 // Transcriptions returns a paginator for retrieving all Transcription objects.
-func (rec *Recording) Transcriptions(client *messagebird.Client) *Paginator {
-	path := rec.links["self"] + "/transcriptions"
+func (rec *Recording) Transcriptions(client *messagebird.Client, callID string) *Paginator {
+	path := apiRoot+rec.links["self"]+"/transcriptions"
 	return newPaginator(client, path, reflect.TypeOf(Transcription{}))
 }
 

--- a/voice/transcription.go
+++ b/voice/transcription.go
@@ -20,9 +20,8 @@ type Transcription struct {
 	ID string
 	// The ID of the recording that the transcription belongs to.
 	RecordingID string
-	// In case that an error was occurred while executing the transcription
-	// request, it appears here.
-	Error string
+	// The status of the transcription. Possible values: created, transcribing, done, failed.
+	Status string
 	// The date-time the transcription was created/requested.
 	CreatedAt time.Time
 	// The date-time the transcription was last updated.
@@ -37,7 +36,7 @@ type Transcription struct {
 type jsonTranscription struct {
 	ID          string            `json:"id"`
 	RecordingID string            `json:"recordingID"`
-	Error       string            `json:"error"`
+	Status      string            `json:"status"`
 	CreatedAt   string            `json:"createdAt"`
 	UpdatedAt   string            `json:"updatedAt"`
 	Links       map[string]string `json:"_links"`
@@ -51,16 +50,16 @@ func (trans *Transcription) UnmarshalJSON(data []byte) error {
 	}
 	createdAt, err := time.Parse(time.RFC3339, raw.CreatedAt)
 	if err != nil {
-		return fmt.Errorf("unable to parse Recording CreatedAt: %v", err)
+		return fmt.Errorf("unable to parse Transcription CreatedAt: %v", err)
 	}
 	updatedAt, err := time.Parse(time.RFC3339, raw.UpdatedAt)
 	if err != nil {
-		return fmt.Errorf("unable to parse Recording UpdatedAt: %v", err)
+		return fmt.Errorf("unable to parse Transcription UpdatedAt: %v", err)
 	}
 	*trans = Transcription{
 		ID:          raw.ID,
 		RecordingID: raw.RecordingID,
-		Error:       raw.Error,
+		Status:      raw.Status,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
 		links:       raw.Links,
@@ -104,7 +103,7 @@ func CreateTranscription(client *messagebird.Client, callID string, legID string
 		return nil, err
 	}
 	if len(resp.Data) == 0 {
-		return nil, fmt.Errorf("Empty response")
+		return nil, fmt.Errorf("empty response")
 	}
 
 	return &resp.Data[0], nil


### PR DESCRIPTION
Added field "Transcribe" to CallFlowRecordStep object. 
Fixed values for MaxLength and Timeout in CallFlowRecordStep object.
Fixed Transcriptions in recordings.
Replace field "error" with field "status" in Transcription object.