### PR TITLE
Remove the feature flag for whatsapp sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,6 @@ if err != nil {
 }
 ```
 
-Conversations WhatsApp Sandbox
--------------
-To use the whatsapp sandbox you need to enable the `FeatureConversationsAPIWhatsAppSandbox` feature.
-
-```go
-	client.EnableFeatures(messagebird.FeatureConversationsAPIWhatsAppSandbox)
-```
-
 Documentation
 -------------
 Complete documentation, instructions, and examples are available at:

--- a/client.go
+++ b/client.go
@@ -46,11 +46,6 @@ var (
 // A Feature can be enabled
 type Feature int
 
-const (
-	// FeatureConversationsAPIWhatsAppSandbox Enables the WhatsApp sandbox for conversations API.
-	FeatureConversationsAPIWhatsAppSandbox Feature = iota
-)
-
 // Client is used to access API with a given key.
 // Uses standard lib HTTP client internally, so should be reused instead of created as needed and it is safe for concurrent use.
 type Client struct {

--- a/conversation/api.go
+++ b/conversation/api.go
@@ -16,8 +16,6 @@ const (
 	// https://conversations.messagebird.com/v1/webhooks).
 	apiRoot = "https://conversations.messagebird.com/v1"
 
-	whatsappSandboxAPIRoot = "https://whatsapp-sandbox.messagebird.com/v1"
-
 	// path is the path for the Conversation resource, relative to apiRoot.
 	path = "conversations"
 
@@ -220,13 +218,7 @@ const (
 // prefix the path with the Conversation API's root. This ensures the client
 // doesn't "handle" this for us: by default, it uses the REST API.
 func request(c *messagebird.Client, v interface{}, method, path string, data interface{}) error {
-	var root string
-	if c.IsFeatureEnabled(messagebird.FeatureConversationsAPIWhatsAppSandbox) {
-		root = whatsappSandboxAPIRoot
-	} else {
-		root = apiRoot
-	}
-	return c.Request(v, method, fmt.Sprintf("%s/%s", root, path), data)
+	return c.Request(v, method, fmt.Sprintf("%s/%s", apiRoot, path), data)
 }
 
 // paginationQuery builds the query string for paginated endpoints.


### PR DESCRIPTION
Whatsapp sandbox is now available as a channel in conversations so we don't need a separate endpoint for it anymore