### PR TITLE
improvement(conversation) allow pass option as nil to list all

### DIFF
--- a/conversation/conversation.go
+++ b/conversation/conversation.go
@@ -29,10 +29,13 @@ var DefaultListOptions = &ListOptions{10, 0}
 
 // List gets a collection of Conversations. Pagination can be set in options.
 func List(c *messagebird.Client, options *ListOptions) (*ConversationList, error) {
-	query := paginationQuery(options)
+	query := "?"
+	if options != nil {
+		query += paginationQuery(options)
+	}
 
 	convList := &ConversationList{}
-	if err := request(c, convList, http.MethodGet, path+"?"+query, nil); err != nil {
+	if err := request(c, convList, http.MethodGet, path+query, nil); err != nil {
 		return nil, err
 	}
 

--- a/conversation/conversation_test.go
+++ b/conversation/conversation_test.go
@@ -13,27 +13,57 @@ func TestMain(m *testing.M) {
 }
 
 func TestList(t *testing.T) {
-	mbtest.WillReturnTestdata(t, "conversationListObject.json", http.StatusOK)
-	client := mbtest.Client(t)
+	t.Run("limit_offset", func(t *testing.T) {
+		mbtest.WillReturnTestdata(t, "conversationListObject.json", http.StatusOK)
+		client := mbtest.Client(t)
 
-	convList, err := List(client, &ListOptions{10, 20})
-	if err != nil {
-		t.Fatalf("unexpected error listing Conversations: %s", err)
-	}
+		convList, err := List(client, &ListOptions{10, 20})
+		if err != nil {
+			t.Fatalf("unexpected error listing Conversations: %s", err)
+		}
 
-	if convList.Offset != 20 {
-		t.Fatalf("got %d, expected 20", convList.Offset)
-	}
+		if convList.Offset != 20 {
+			t.Fatalf("got %d, expected 20", convList.Offset)
+		}
 
-	if convList.Items[0].ID != "convid" {
-		t.Fatalf("got %s, expected convid", convList.Items[0].ID)
-	}
+		if convList.Items[0].ID != "convid" {
+			t.Fatalf("got %s, expected convid", convList.Items[0].ID)
+		}
 
-	mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/conversations")
+		mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/conversations")
 
-	if query := mbtest.Request.URL.RawQuery; query != "limit=10&offset=20" {
-		t.Fatalf("got %s, expected limit=10&offset=20", query)
-	}
+		if query := mbtest.Request.URL.RawQuery; query != "limit=10&offset=20" {
+			t.Fatalf("got %s, expected limit=10&offset=20", query)
+		}
+	})
+
+	t.Run("all", func(t *testing.T) {
+		mbtest.WillReturnTestdata(t, "allConversationListObject.json", http.StatusOK)
+		client := mbtest.Client(t)
+
+		convList, err := List(client, nil)
+		if err != nil {
+			t.Fatalf("unexpected error listing Conversations: %s", err)
+		}
+
+		if convList.Offset != 0 {
+			t.Fatalf("got offset=%d, expected 0", convList.Offset)
+		}
+
+		if convList.Limit != 10 {
+			t.Fatalf("got limit=%d, expected 10", convList.Limit)
+		}
+
+		if convList.Items[0].ID != "convid" {
+			t.Fatalf("got %s, expected convid", convList.Items[0].ID)
+		}
+
+		mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/conversations")
+
+		if query := mbtest.Request.URL.RawQuery; query != "" {
+			t.Fatalf("got %s, expected no limit and offset", query)
+		}
+	})
 }
 
 func TestRead(t *testing.T) {

--- a/conversation/testdata/allConversationListObject.json
+++ b/conversation/testdata/allConversationListObject.json
@@ -1,0 +1,46 @@
+{
+    "offset": 0,
+    "limit": 10,
+    "count": 1,
+    "totalCount": 1,
+    "items": [
+        {
+            "id": "convid",
+            "contactId": "contid",
+            "contact": {
+                "id": "contid",
+                "href": "https://chat.messagebird.com/1/contacts/contid",
+                "msisdn": 31612345678,
+                "firstName": "Foo",
+                "lastName": "Bar",
+                "customDetails": {
+                    "avatar": "https://s3-eu-west-1.amazonaws.com/messagebird-chat/telegram/0d1dae7t5b7d7eb4531c14n04328336/6de655at5b7d859309f821n60607065/d0b705dt5b7d859309f987n05372263.jpg",
+                    "firstName": "Foo",
+                    "lastName": "Bar",
+                    "userId": 12345678
+                },
+                "createdDatetime": "2018-08-22T15:47:32Z",
+                "updatedDatetime": null
+            },
+            "channels": [
+                {
+                    "id": "chid",
+                    "name": "TestChannel",
+                    "platformId": "telegram",
+                    "status": "active",
+                    "createdDatetime": "2018-08-22T15:18:11Z",
+                    "updatedDatetime": "2018-08-22T15:18:13Z"
+                }
+            ],
+            "status": "active",
+            "createdDatetime": "2018-08-22T15:47:34Z",
+            "updatedDatetime": "2018-08-24T09:49:01Z",
+            "lastReceivedDatetime": "2018-08-24T09:49:01Z",
+            "lastUsedChannelId": "chid",
+            "messages": {
+                "totalCount": 3,
+                "href": "https://conversations.messagebird.com/v1/conversations/convid/messages"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
It's require to define limit and offset to list conversations. This pull request allow to list conversations without passing this options (list all).

It also avoid the sdk to crash(panic) in case options is set to nil.