### PR TITLE
improvement(conversations lists) allow pass option as nil to list all

### DIFF
--- a/conversation/api.go
+++ b/conversation/api.go
@@ -231,6 +231,10 @@ func request(c *messagebird.Client, v interface{}, method, path string, data int
 
 // paginationQuery builds the query string for paginated endpoints.
 func paginationQuery(options *ListOptions) string {
+	if options == nil {
+		return ""
+	}
+
 	query := url.Values{}
 	query.Set("limit", strconv.Itoa(options.Limit))
 	query.Set("offset", strconv.Itoa(options.Offset))

--- a/conversation/conversation.go
+++ b/conversation/conversation.go
@@ -1,6 +1,7 @@
 package conversation
 
 import (
+	"fmt"
 	"net/http"
 
 	messagebird "github.com/messagebird/go-rest-api"
@@ -29,13 +30,10 @@ var DefaultListOptions = &ListOptions{10, 0}
 
 // List gets a collection of Conversations. Pagination can be set in options.
 func List(c *messagebird.Client, options *ListOptions) (*ConversationList, error) {
-	query := "?"
-	if options != nil {
-		query += paginationQuery(options)
-	}
+	query := paginationQuery(options)
 
 	convList := &ConversationList{}
-	if err := request(c, convList, http.MethodGet, path+query, nil); err != nil {
+	if err := request(c, convList, http.MethodGet, fmt.Sprintf("%s?%s", path, query), nil); err != nil {
 		return nil, err
 	}
 

--- a/conversation/testdata/allMessageListObject.json
+++ b/conversation/testdata/allMessageListObject.json
@@ -1,0 +1,34 @@
+{
+    "count": 2,
+    "items": [
+        {
+            "id": "mesid",
+            "conversationId": "convid",
+            "channelId": "chid",
+            "status": "received",
+            "type": "text",
+            "direction": "received",
+            "content": {
+                "text": "Foo"
+            },
+            "createdDatetime": "2018-08-24T09:49:01Z",
+            "updatedDatetime": "2018-08-24T09:49:01Z"
+        },
+        {
+            "id": "mesid",
+            "conversationId": "convid",
+            "channelId": "chid",
+            "status": "received",
+            "type": "text",
+            "direction": "received",
+            "content": {
+                "text": "Foo"
+            },
+            "createdDatetime": "2018-08-24T09:49:01Z",
+            "updatedDatetime": "2018-08-24T09:49:01Z"
+        }
+    ],
+    "limit": 10,
+    "offset": 0,
+    "totalCount": 2
+}

--- a/conversation/testdata/allWebhookListObject.json
+++ b/conversation/testdata/allWebhookListObject.json
@@ -1,0 +1,28 @@
+{
+    "offset": 0,
+    "limit": 10,
+    "count": 2,
+    "totalCount": 2,
+    "items": [
+        {
+            "id": "whid",
+            "url": "https://example.com/webhooks",
+            "channelId": "chid",
+            "events": [
+                "message.created"
+            ],
+            "createdDatetime": "2018-08-24T14:46:39Z",
+            "updatedDatetime": null
+        },
+        {
+            "id": "whid",
+            "url": "https://example.com/webhooks",
+            "channelId": "chid",
+            "events": [
+                "message.created"
+            ],
+            "createdDatetime": "2018-08-24T14:46:39Z",
+            "updatedDatetime": null
+        }
+    ]
+}

--- a/conversation/testdata/messageListObject.json
+++ b/conversation/testdata/messageListObject.json
@@ -15,7 +15,7 @@
             "updatedDatetime": "2018-08-24T09:49:01Z"
         }
     ],
-    "limit": 10,
-    "offset": 0,
+    "limit": 20,
+    "offset": 2,
     "totalCount": 1
 }


### PR DESCRIPTION
It's require to define limit and offset to list conversation messages. This pull request allow to list conversation messages without passing this options (list all).

It also avoid the sdk to crash(panic) in case options is set to nil.