### PR TITLE
Improve ErrorResponse's Error() implementation to be more specific.

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,7 +1,8 @@
 package messagebird
 
-const (
-	apiErrMessage = "The MessageBird API returned an error"
+import (
+	"fmt"
+	"strings"
 )
 
 // Error holds details including error code, human readable description and optional parameter that is related to the error.
@@ -23,5 +24,9 @@ type ErrorResponse struct {
 
 // Error implements error interface.
 func (r ErrorResponse) Error() string {
-	return apiErrMessage
+	var inners []string
+	for _, inner := range r.Errors {
+		inners = append(inners, inner.Error())
+	}
+	return fmt.Sprintf("API errors: %s", strings.Join(inners, ", "))
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,42 @@
+package messagebird
+
+import (
+	"testing"
+)
+
+func TestError(t *testing.T) {
+	t.Run("Single", func(t *testing.T) {
+		errRes := ErrorResponse{
+			Errors: []Error{
+				Error{
+					Code:        42,
+					Description: "something bad",
+					Parameter:   "foo",
+				},
+			},
+		}
+		if s := errRes.Error(); s != "API errors: something bad" {
+			t.Errorf("Got %q, expected API response: something bad", s)
+		}
+	})
+
+	t.Run("Multiple", func(t *testing.T) {
+		errRes := ErrorResponse{
+			Errors: []Error{
+				Error{
+					Code:        42,
+					Description: "something bad",
+					Parameter:   "foo",
+				},
+				Error{
+					Code:        42,
+					Description: "something else",
+					Parameter:   "foo",
+				},
+			},
+		}
+		if s := errRes.Error(); s != "API errors: something bad, something else" {
+			t.Errorf("Got %q, expected API response: something bad, something else", s)
+		}
+	})
+}


### PR DESCRIPTION
It turns out most clients rely on the built-in error interface, and
don't explicitly cast to ErrorResponse. Those clients would only see
a very generic "The MessageBird API is currently unavailable" message.
After this change, Error() will return a concatenated list of the
actual error descriptions returned by the MessageBird APIs. If desired,
clients can still cast to ErrorReponse to inspect the "code" and "param"
fields for the individual API errors