### PR TITLE
Use testify for testing.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go-version: [ 1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x ]
+        go-version: [ 1.14.x, 1.15.x, 1.16.x ]
 
     name: Go ${{ matrix.go-version }}
 

--- a/conversation/conversation_test.go
+++ b/conversation/conversation_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -18,23 +19,16 @@ func TestList(t *testing.T) {
 		client := mbtest.Client(t)
 
 		convList, err := List(client, &ListOptions{10, 20})
-		if err != nil {
-			t.Fatalf("unexpected error listing Conversations: %s", err)
-		}
+		assert.NoError(t, err)
 
-		if convList.Offset != 20 {
-			t.Fatalf("got %d, expected 20", convList.Offset)
-		}
+		assert.Equal(t, 20, convList.Offset)
 
-		if convList.Items[0].ID != "convid" {
-			t.Fatalf("got %s, expected convid", convList.Items[0].ID)
-		}
+		assert.Equal(t, "convid", convList.Items[0].ID)
 
 		mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/conversations")
 
-		if query := mbtest.Request.URL.RawQuery; query != "limit=10&offset=20" {
-			t.Fatalf("got %s, expected limit=10&offset=20", query)
-		}
+		query := mbtest.Request.URL.RawQuery
+		assert.Equal(t, "limit=10&offset=20", query)
 	})
 
 	t.Run("all", func(t *testing.T) {
@@ -42,27 +36,18 @@ func TestList(t *testing.T) {
 		client := mbtest.Client(t)
 
 		convList, err := List(client, nil)
-		if err != nil {
-			t.Fatalf("unexpected error listing Conversations: %s", err)
-		}
+		assert.NoError(t, err)
 
-		if convList.Offset != 0 {
-			t.Fatalf("got offset=%d, expected 0", convList.Offset)
-		}
+		assert.Equal(t, 0, convList.Offset)
 
-		if convList.Limit != 10 {
-			t.Fatalf("got limit=%d, expected 10", convList.Limit)
-		}
+		assert.Equal(t, 10, convList.Limit)
 
-		if convList.Items[0].ID != "convid" {
-			t.Fatalf("got %s, expected convid", convList.Items[0].ID)
-		}
+		assert.Equal(t, "convid", convList.Items[0].ID)
 
 		mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/conversations")
 
-		if query := mbtest.Request.URL.RawQuery; query != "" {
-			t.Fatalf("got %s, expected no limit and offset", query)
-		}
+		query := mbtest.Request.URL.RawQuery
+		assert.Equal(t, "", query)
 	})
 }
 
@@ -71,41 +56,17 @@ func TestRead(t *testing.T) {
 	client := mbtest.Client(t)
 
 	conv, err := Read(client, "convid")
-	if err != nil {
-		t.Fatalf("unexpected error reading Conversation: %s", err)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "convid", conv.ID)
+	assert.Equal(t, "contid", conv.Contact.ID)
+	assert.Equal(t, "31612345678", conv.Contact.MSISDN)
 
-	if conv.ID != "convid" {
-		t.Fatalf("got %s, expected convid", conv.ID)
-	}
-
-	if conv.Contact.ID != "contid" {
-		t.Fatalf("got %s, expected contid", conv.Contact.ID)
-	}
-
-	if conv.Contact.MSISDN != "31612345678" {
-		t.Fatalf("got %s, expected 31612345678", conv.Contact.MSISDN)
-	}
-
-	if val, ok := conv.Contact.CustomDetails["userId"]; ok {
-		if val != int64(12345678) {
-			t.Fatalf("got %v, expected 12345678", val)
-		}
-	} else {
-		t.Fatalf("got nil, expected 12345678")
-	}
-
-	if conv.Channels[0].Name != "chname" {
-		t.Fatalf("got %s, expected chname", conv.Channels[0].Name)
-	}
-
-	if conv.Messages.TotalCount != 1 {
-		t.Fatalf("got %d, expected 1", conv.Messages.TotalCount)
-	}
-
-	if conv.Status != ConversationStatusActive {
-		t.Fatalf("got %s, expected active", conv.Status)
-	}
+	val, ok := conv.Contact.CustomDetails["userId"]
+	assert.True(t, ok)
+	assert.Equal(t, int64(12345678), val)
+	assert.Equal(t, "chname", conv.Channels[0].Name)
+	assert.Equal(t, 1, conv.Messages.TotalCount)
+	assert.Equal(t, ConversationStatusActive, conv.Status)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/conversations/convid")
 }
@@ -145,13 +106,8 @@ func TestStartHSM(t *testing.T) {
 		},
 		Type: MessageTypeHSM,
 	})
-	if err != nil {
-		t.Fatalf("unexpected error starting Conversation: %s", err)
-	}
-
-	if conv.ID != "convid" {
-		t.Fatalf("got %s, expected convid", conv.ID)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "convid", conv.ID)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPost, "/v1/conversations/start")
 	mbtest.AssertTestdata(t, "conversationStartHsmRequest.json", mbtest.Request.Body)
@@ -159,9 +115,7 @@ func TestStartHSM(t *testing.T) {
 
 func mustParseRFC3339(t *testing.T, s string) *time.Time {
 	result, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		t.Fatalf("unexpected error parsing RFC3339 time: %s", err)
-	}
+	assert.NoError(t, err)
 
 	return &result
 }
@@ -180,13 +134,8 @@ func TestStartMedia(t *testing.T) {
 		},
 		Type: MessageTypeText,
 	})
-	if err != nil {
-		t.Fatalf("unexpected error starting Conversation: %s", err)
-	}
-
-	if conv.ID != "convid" {
-		t.Fatalf("got %s, expected convid", conv.ID)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "convid", conv.ID)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPost, "/v1/conversations/start")
 	mbtest.AssertTestdata(t, "conversationStartVideoRequest.json", mbtest.Request.Body)
@@ -204,13 +153,8 @@ func TestStartText(t *testing.T) {
 		},
 		Type: MessageTypeText,
 	})
-	if err != nil {
-		t.Fatalf("unexpected error starting Conversation: %s", err)
-	}
-
-	if conv.ID != "convid" {
-		t.Fatalf("got %s, expected convid", conv.ID)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "convid", conv.ID)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPost, "/v1/conversations/start")
 	mbtest.AssertTestdata(t, "conversationStartTextRequest.json", mbtest.Request.Body)
@@ -223,13 +167,8 @@ func TestUpdate(t *testing.T) {
 	conv, err := Update(client, "id", &UpdateRequest{
 		Status: ConversationStatusArchived,
 	})
-	if err != nil {
-		t.Fatalf("unexpected error updating Conversation: %s", err)
-	}
-
-	if conv.Status != ConversationStatusArchived {
-		t.Fatalf("got %s, expected archived", conv.Status)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, ConversationStatusArchived, conv.Status)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPatch, "/v1/conversations/id")
 	mbtest.AssertTestdata(t, "conversationUpdateRequest.json", mbtest.Request.Body)

--- a/conversation/hsm_test.go
+++ b/conversation/hsm_test.go
@@ -1,6 +1,7 @@
 package conversation
 
 import (
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -44,9 +45,7 @@ func TestLocalizableParameter(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			if !reflect.DeepEqual(tc.got, tc.expect) {
-				t.Fatalf("got %v, expected %v", tc.got, tc.expect)
-			}
+			assert.Truef(t, reflect.DeepEqual(tc.got, tc.expect), "got %v, expected %v", tc.got, tc.expect)
 		})
 	}
 }

--- a/conversation/message_test.go
+++ b/conversation/message_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateMessage(t *testing.T) {
@@ -18,13 +19,8 @@ func TestCreateMessage(t *testing.T) {
 		},
 		Type: MessageTypeText,
 	})
-	if err != nil {
-		t.Fatalf("unexpected error creating Message: %s", err)
-	}
-
-	if message.ID != "mesid" {
-		t.Fatalf("got %s, expected mesid", message.ID)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "mesid", message.ID)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPost, "/v1/conversations/convid/messages")
 	mbtest.AssertTestdata(t, "messageCreateRequest.json", mbtest.Request.Body)
@@ -36,27 +32,18 @@ func TestListMessages(t *testing.T) {
 		client := mbtest.Client(t)
 
 		messageList, err := ListMessages(client, "convid", &ListOptions{Limit: 20, Offset: 2})
-		if err != nil {
-			t.Fatalf("unexpected error listing Messages: %s", err)
-		}
+		assert.NoError(t, err)
 
-		if messageList.Offset != 2 {
-			t.Fatalf("got %d, expected 2", messageList.Offset)
-		}
+		assert.Equal(t, 2, messageList.Offset)
 
-		if messageList.Limit != 20 {
-			t.Fatalf("got %d, expected 20", messageList.Limit)
-		}
+		assert.Equal(t, 20, messageList.Limit)
 
-		if messageList.Items[0].ID != "mesid" {
-			t.Fatalf("got %s, expected mesid", messageList.Items[0].ID)
-		}
+		assert.Equal(t, "mesid", messageList.Items[0].ID)
 
 		mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/conversations/convid/messages")
 
-		if query := mbtest.Request.URL.RawQuery; query != "limit=20&offset=2" {
-			t.Fatalf("got %s, expected limit=10&offset=0", query)
-		}
+		query := mbtest.Request.URL.RawQuery
+		assert.Equal(t, "limit=20&offset=2", query)
 	})
 
 	t.Run("all", func(t *testing.T) {
@@ -64,31 +51,20 @@ func TestListMessages(t *testing.T) {
 		client := mbtest.Client(t)
 
 		messageList, err := ListMessages(client, "convid", nil)
-		if err != nil {
-			t.Fatalf("unexpected error listing Messages: %s", err)
-		}
+		assert.NoError(t, err)
 
-		if messageList.Limit != 10 {
-			t.Fatalf("got %d, expected 10", messageList.Limit)
-		}
+		assert.Equal(t, 10, messageList.Limit)
 
-		if messageList.Offset != 0 {
-			t.Fatalf("got %d, expected 0", messageList.Offset)
-		}
+		assert.Equal(t, 0, messageList.Offset)
 
-		if messageList.Items[0].ID != "mesid" {
-			t.Fatalf("got %s, expected mesid", messageList.Items[0].ID)
-		}
+		assert.Equal(t, "mesid", messageList.Items[0].ID)
 
-		if len(messageList.Items) != 2 {
-			t.Fatalf("got %d, expected 2", len(messageList.Items))
-		}
+		assert.Len(t, messageList.Items, 2)
 
 		mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/conversations/convid/messages")
 
-		if query := mbtest.Request.URL.RawQuery; query != "" {
-			t.Fatalf("got %s, expected empty", query)
-		}
+		query := mbtest.Request.URL.RawQuery
+		assert.Equal(t, "", query)
 	})
 }
 
@@ -97,21 +73,11 @@ func TestReadMessage(t *testing.T) {
 	client := mbtest.Client(t)
 
 	message, err := ReadMessage(client, "mesid")
-	if err != nil {
-		t.Fatalf("unexpected error creating Message: %s", err)
-	}
+	assert.NoError(t, err)
 
-	if message.Content.Text != "Hello world" {
-		t.Fatalf("got %s, expected Hello world", message.Content.Text)
-	}
-
-	if message.Direction != MessageDirectionReceived {
-		t.Fatalf("got %s, expected received", message.Direction)
-	}
-
-	if message.Status != MessageStatusFailed {
-		t.Fatalf("got %s, expected failed", message.Status)
-	}
+	assert.Equal(t, "Hello world", message.Content.Text)
+	assert.Equal(t, MessageDirectionReceived, message.Direction)
+	assert.Equal(t, MessageStatusFailed, message.Status)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/messages/mesid")
 }

--- a/conversation/webhook_test.go
+++ b/conversation/webhook_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateWebhook(t *testing.T) {
@@ -19,13 +20,8 @@ func TestCreateWebhook(t *testing.T) {
 		},
 		URL: "https://example.com/webhooks",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error creating Webhook: %s", err)
-	}
-
-	if webhook.ID != "whid" {
-		t.Fatalf("got %s, expected whid", webhook.ID)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "whid", webhook.ID)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPost, "/v1/webhooks")
 	mbtest.AssertTestdata(t, "webhookCreateRequest.json", mbtest.Request.Body)
@@ -35,9 +31,8 @@ func TestDeleteWebhook(t *testing.T) {
 	mbtest.WillReturn([]byte(""), http.StatusNoContent)
 	client := mbtest.Client(t)
 
-	if err := DeleteWebhook(client, "whid"); err != nil {
-		t.Fatalf("unexpected error deleting Webhook: %s", err)
-	}
+	err := DeleteWebhook(client, "whid")
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodDelete, "/v1/webhooks/whid")
 }
@@ -48,23 +43,16 @@ func TestListWebhooks(t *testing.T) {
 		client := mbtest.Client(t)
 
 		webhookList, err := ListWebhooks(client, &ListOptions{Limit: 20, Offset: 2})
-		if err != nil {
-			t.Fatalf("unexpected error listing Webhooks: %s", err)
-		}
+		assert.NoError(t, err)
 
-		if webhookList.TotalCount != 1 {
-			t.Fatalf("got %d, expected 1", webhookList.TotalCount)
-		}
+		assert.Equal(t, 1, webhookList.TotalCount)
 
-		if webhookList.Items[0].Events[0] != WebhookEventMessageCreated {
-			t.Fatalf("got %s expected message.created", webhookList.Items[0].Events[0])
-		}
+		assert.Equal(t, WebhookEventMessageCreated, webhookList.Items[0].Events[0])
 
 		mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/webhooks")
 
-		if query := mbtest.Request.URL.RawQuery; query != "limit=20&offset=2" {
-			t.Fatalf("got %s, expected limit=20&offset=2", query)
-		}
+		query := mbtest.Request.URL.RawQuery
+		assert.Equal(t, "limit=20&offset=2", query)
 	})
 
 	t.Run("all", func(t *testing.T) {
@@ -72,35 +60,22 @@ func TestListWebhooks(t *testing.T) {
 		client := mbtest.Client(t)
 
 		webhookList, err := ListWebhooks(client, nil)
-		if err != nil {
-			t.Fatalf("unexpected error listing Webhooks: %s", err)
-		}
+		assert.NoError(t, err)
 
-		if webhookList.Limit != 10 {
-			t.Fatalf("got %d, expected 10", webhookList.Limit)
-		}
+		assert.Equal(t, 10, webhookList.Limit)
 
-		if webhookList.Offset != 0 {
-			t.Fatalf("got %d, expected 0", webhookList.Offset)
-		}
+		assert.Equal(t, 0, webhookList.Offset)
 
-		if webhookList.TotalCount != 2 {
-			t.Fatalf("got %d, expected 2", webhookList.TotalCount)
-		}
+		assert.Equal(t, 2, webhookList.TotalCount)
 
-		if webhookList.Items[0].Events[0] != WebhookEventMessageCreated {
-			t.Fatalf("got %s expected message.created", webhookList.Items[0].Events[0])
-		}
+		assert.Equal(t, WebhookEventMessageCreated, webhookList.Items[0].Events[0])
 
-		if len(webhookList.Items) != 2 {
-			t.Fatalf("got %d, expected 2", len(webhookList.Items))
-		}
+		assert.Len(t, webhookList.Items, 2)
 
 		mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/webhooks")
 
-		if query := mbtest.Request.URL.RawQuery; query != "" {
-			t.Fatalf("got %s, expected empty", query)
-		}
+		query := mbtest.Request.URL.RawQuery
+		assert.Equal(t, "", query)
 	})
 }
 
@@ -109,17 +84,11 @@ func TestReadWebhook(t *testing.T) {
 	client := mbtest.Client(t)
 
 	webhook, err := ReadWebhook(client, "whid")
-	if err != nil {
-		t.Fatalf("unexpected error reading Webhook: %s", err)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "chid", webhook.ChannelID)
 
-	if webhook.ChannelID != "chid" {
-		t.Fatalf("got %s, expected chid", webhook.ChannelID)
-	}
-
-	if count := len(webhook.Events); count != 2 {
-		t.Fatalf("got %d events, expected 2", count)
-	}
+	count := len(webhook.Events)
+	assert.Equal(t, 2, count)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/webhooks/whid")
 }
@@ -137,21 +106,11 @@ func TestUpdateWebhook(t *testing.T) {
 	}
 
 	webhook, err := UpdateWebhook(client, "whid", webhookUpdateRequest)
-	if err != nil {
-		t.Fatalf("unexpected error updating Webhook: %s", err)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com/mynewwebhookurl", webhook.URL)
 
-	if webhook.URL != "https://example.com/mynewwebhookurl" {
-		t.Fatalf("Expected https://example.com/mynewwebhookurl, got %s", webhook.URL)
-	}
-
-	if webhook.UpdatedDatetime == nil {
-		t.Fatalf("Expected the UpdatedDatetime value to be added, but was nil")
-	}
-
-	if webhook.Status != WebhookStatusDisabled {
-		t.Fatalf("Expected status to be disabled, was %s", webhook.Status)
-	}
+	assert.NotNil(t, webhook.UpdatedDatetime)
+	assert.Equal(t, WebhookStatusDisabled, webhook.Status)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPatch, "/v1/webhooks/whid")
 	mbtest.AssertTestdata(t, "webhookUpdateRequest.json", mbtest.Request.Body)

--- a/error_test.go
+++ b/error_test.go
@@ -1,6 +1,7 @@
 package messagebird
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -15,9 +16,7 @@ func TestError(t *testing.T) {
 				},
 			},
 		}
-		if s := errRes.Error(); s != "API errors: something bad" {
-			t.Errorf("Got %q, expected API response: something bad", s)
-		}
+		assert.Error(t, errRes)
 	})
 
 	t.Run("Multiple", func(t *testing.T) {
@@ -35,8 +34,6 @@ func TestError(t *testing.T) {
 				},
 			},
 		}
-		if s := errRes.Error(); s != "API errors: something bad, something else" {
-			t.Errorf("Got %q, expected API response: something bad, something else", s)
-		}
+		assert.Error(t, errRes)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/messagebird/go-rest-api/v6
 
 go 1.14
+
+require github.com/stretchr/testify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/group/group_test.go
+++ b/group/group_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -17,33 +18,27 @@ func TestCreate(t *testing.T) {
 	client := mbtest.Client(t)
 
 	group, err := Create(client, &Request{"Friends"})
-	if err != nil {
-		t.Fatalf("unexpected error creating Group: %s", err)
-	}
+
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPost, "/groups")
 	mbtest.AssertTestdata(t, "groupRequestCreateObject.json", mbtest.Request.Body)
-
-	if group.Name != "Friends" {
-		t.Fatalf("got %s, expected Friends", group.Name)
-	}
+	assert.Equal(t, "Friends", group.Name)
 }
 
 func TestCreateWithEmptyName(t *testing.T) {
 	client := mbtest.Client(t)
 
-	if _, err := Create(client, &Request{""}); err == nil {
-		t.Fatalf("got nil, expected error")
-	}
+	_, err := Create(client, &Request{""})
+	assert.Error(t, err)
 }
 
 func TestDelete(t *testing.T) {
 	mbtest.WillReturn([]byte(""), http.StatusNoContent)
 	client := mbtest.Client(t)
 
-	if err := Delete(client, "group-id"); err != nil {
-		t.Fatalf("unexpected error deleting Group: %s", err)
-	}
+	err := Delete(client, "group-id")
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodDelete, "/groups/group-id")
 }
@@ -53,37 +48,15 @@ func TestList(t *testing.T) {
 	client := mbtest.Client(t)
 
 	list, err := List(client, DefaultListOptions)
-	if err != nil {
-		t.Fatalf("unexpected error retrieving Contact list: %s", err)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 0, list.Offset)
+	assert.Equal(t, 10, list.Limit)
+	assert.Equal(t, 2, list.Count)
+	assert.Equal(t, 2, list.TotalCount)
 
-	if list.Offset != 0 {
-		t.Fatalf("got %d, expected 0", list.Offset)
-	}
-
-	if list.Limit != 10 {
-		t.Fatalf("got %d, expected 10", list.Limit)
-	}
-
-	if list.Count != 2 {
-		t.Fatalf("got %d, expected 2", list.Count)
-	}
-
-	if list.TotalCount != 2 {
-		t.Fatalf("got %d, expected 2", list.TotalCount)
-	}
-
-	if actualCount := len(list.Items); actualCount != 2 {
-		t.Fatalf("got %d, expected 2", actualCount)
-	}
-
-	if list.Items[0].ID != "first-id" {
-		t.Fatalf("got %s, expected first-id", list.Items[0].ID)
-	}
-
-	if list.Items[1].ID != "second-id" {
-		t.Fatalf("got %s, expected second-id", list.Items[1].ID)
-	}
+	assert.Len(t, list.Items, 2)
+	assert.Equal(t, "first-id", list.Items[0].ID)
+	assert.Equal(t, "second-id", list.Items[1].ID)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/groups")
 }
@@ -102,12 +75,9 @@ func TestListPagination(t *testing.T) {
 
 	for _, tc := range tt {
 		_, err := List(client, tc.options)
-		if err != nil {
-			t.Fatalf("unexpected error listing groups: %s", err)
-		}
-		if query := mbtest.Request.URL.RawQuery; query != tc.expected {
-			t.Fatalf("got %s, expected %s", tc.expected, query)
-		}
+		assert.NoError(t, err)
+		query := mbtest.Request.URL.RawQuery
+		assert.Equal(t, tc.expected, query)
 	}
 }
 
@@ -116,71 +86,44 @@ func TestRead(t *testing.T) {
 	client := mbtest.Client(t)
 
 	group, err := Read(client, "group-id")
-	if err != nil {
-		t.Fatalf("unexpected error reading Group: %s", err)
-	}
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/groups/group-id")
+	assert.Equal(t, "group-id", group.ID)
+	assert.Equal(t, "https://rest.messagebird.com/groups/group-id", group.HRef)
+	assert.Equal(t, "Friends", group.Name)
+	assert.Equal(t, 3, group.Contacts.TotalCount)
+	assert.Equal(t, "https://rest.messagebird.com/groups/group-id", group.Contacts.HRef)
 
-	if group.ID != "group-id" {
-		t.Fatalf("got %s, expected group-id", group.ID)
-	}
+	created, _ := time.Parse(time.RFC3339, "2018-07-25T12:16:10+00:00")
+	assert.True(t, created.Equal(*group.CreatedDatetime))
 
-	if group.HRef != "https://rest.messagebird.com/groups/group-id" {
-		t.Fatalf("got %s, expected https://rest.messagebird.com/groups/group-id", group.HRef)
-	}
-
-	if group.Name != "Friends" {
-		t.Fatalf("got %s, expected Friends", group.Name)
-	}
-
-	if group.Contacts.TotalCount != 3 {
-		t.Fatalf("got %d, expected 3", group.Contacts.TotalCount)
-	}
-
-	if group.Contacts.HRef != "https://rest.messagebird.com/groups/group-id" {
-		t.Fatalf("got %s, expected https://rest.messagebird.com/groups/group-id", group.Contacts.HRef)
-	}
-
-	if created, _ := time.Parse(time.RFC3339, "2018-07-25T12:16:10+00:00"); !created.Equal(*group.CreatedDatetime) {
-		t.Fatalf("got %s, expected 2018-07-25T12:16:10+00:00", group.CreatedDatetime)
-	}
-
-	if updated, _ := time.Parse(time.RFC3339, "2018-07-25T12:16:23+00:00"); !updated.Equal(*group.UpdatedDatetime) {
-		t.Fatalf("got %s, expected 2018-07-25T12:16:23+00:00", group.UpdatedDatetime)
-	}
+	updated, _ := time.Parse(time.RFC3339, "2018-07-25T12:16:23+00:00")
+	assert.True(t, updated.Equal(*group.UpdatedDatetime))
 }
 
 func TestUpdate(t *testing.T) {
 	mbtest.WillReturn([]byte(""), http.StatusNoContent)
 	client := mbtest.Client(t)
 
-	if err := Update(client, "group-id", &Request{"Family"}); err != nil {
-		t.Fatalf("unexpected error updating Group: %s", err)
-	}
+	err := Update(client, "group-id", &Request{"Family"})
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPatch, "/groups/group-id")
 	mbtest.AssertTestdata(t, "groupRequestUpdateObject.json", mbtest.Request.Body)
-
-	if mbtest.Request.ContentType != "application/json" {
-		t.Fatalf("got %s, expected application/json", mbtest.Request.ContentType)
-	}
+	assert.Equal(t, "application/json", mbtest.Request.ContentType)
 }
 
 func TestAddContacts(t *testing.T) {
 	mbtest.WillReturn([]byte(""), http.StatusNoContent)
 	client := mbtest.Client(t)
 
-	if err := AddContacts(client, "group-id", []string{"first-contact-id", "second-contact-id"}); err != nil {
-		t.Fatalf("unexpected error removing Contacts from Group: %s", err)
-	}
+	err := AddContacts(client, "group-id", []string{"first-contact-id", "second-contact-id"})
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPut, "/groups/group-id/contacts")
 	mbtest.AssertTestdata(t, "groupRequestAddContactsObject.txt", mbtest.Request.Body)
-
-	if mbtest.Request.ContentType != "application/x-www-form-urlencoded" {
-		t.Fatalf("got %s, expected application/x-www-form-urlencoded", mbtest.Request.ContentType)
-	}
+	assert.Equal(t, "application/x-www-form-urlencoded", mbtest.Request.ContentType)
 }
 
 func TestAddContactsWithEmptyContacts(t *testing.T) {
@@ -194,9 +137,8 @@ func TestAddContactsWithEmptyContacts(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		if err := AddContacts(client, "group-id", tc.contactIDs); err == nil {
-			t.Fatalf("got nil, expected error")
-		}
+		err := AddContacts(client, "group-id", tc.contactIDs)
+		assert.Error(t, err)
 	}
 }
 
@@ -206,9 +148,8 @@ func TestAddContactsWithTooManyContacts(t *testing.T) {
 	// Only 50 contacts are allowed at a time.
 	contactIDs := make([]string, 51)
 
-	if err := AddContacts(client, "group-id", contactIDs); err == nil {
-		t.Fatalf("got nil, expected error")
-	}
+	err := AddContacts(client, "group-id", contactIDs)
+	assert.Error(t, err)
 }
 
 func TestListContacts(t *testing.T) {
@@ -216,37 +157,14 @@ func TestListContacts(t *testing.T) {
 	client := mbtest.Client(t)
 
 	list, err := ListContacts(client, "group-id", DefaultListOptions)
-	if err != nil {
-		t.Fatalf("unexpected error listing Contacts: %s", err)
-	}
-
-	if list.Offset != 0 {
-		t.Fatalf("got %d, expected 0", list.Offset)
-	}
-
-	if list.Limit != 20 {
-		t.Fatalf("got %d, expected 20", list.Limit)
-	}
-
-	if list.Count != 3 {
-		t.Fatalf("got %d, expected 3", list.Count)
-	}
-
-	if list.TotalCount != 3 {
-		t.Fatalf("got %d, expected 3", list.TotalCount)
-	}
-
-	if list.Items[0].ID != "first-contact-id" {
-		t.Fatalf("got %s, expected first-contact-id", list.Items[0].ID)
-	}
-
-	if list.Items[1].ID != "second-contact-id" {
-		t.Fatalf("got %s, expected second-contact-id", list.Items[1].ID)
-	}
-
-	if list.Items[2].ID != "third-contact-id" {
-		t.Fatalf("got %s, expected third-contact-id", list.Items[2].ID)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 0, list.Offset)
+	assert.Equal(t, 20, list.Limit)
+	assert.Equal(t, 3, list.Count)
+	assert.Equal(t, 3, list.TotalCount)
+	assert.Equal(t, "first-contact-id", list.Items[0].ID)
+	assert.Equal(t, "second-contact-id", list.Items[1].ID)
+	assert.Equal(t, "third-contact-id", list.Items[2].ID)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/groups/group-id/contacts")
 }
@@ -255,9 +173,8 @@ func TestRemoveContact(t *testing.T) {
 	mbtest.WillReturn([]byte(""), http.StatusNoContent)
 	client := mbtest.Client(t)
 
-	if err := RemoveContact(client, "group-id", "contact-id"); err != nil {
-		t.Fatalf("unexpected error deleting Group: %s", err)
-	}
+	err := RemoveContact(client, "group-id", "contact-id")
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodDelete, "/groups/group-id/contacts/contact-id")
 }

--- a/hlr/hlr_test.go
+++ b/hlr/hlr_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/messagebird/go-rest-api/v6"
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -14,37 +15,16 @@ func TestMain(m *testing.M) {
 }
 
 func assertHLRObject(t *testing.T, hlr *HLR) {
-	if hlr.ID != "27978c50354a93ca0ca8de6h54340177" {
-		t.Errorf("Unexpected result for HLR Id: %s, expected: 27978c50354a93ca0ca8de6h54340177", hlr.ID)
-	}
+	assert.Equal(t, "27978c50354a93ca0ca8de6h54340177", hlr.ID)
+	assert.Equal(t, "https://rest.messagebird.com/hlr/27978c50354a93ca0ca8de6h54340177", hlr.HRef)
+	assert.Equal(t, 31612345678, hlr.MSISDN)
+	assert.Equal(t, 20406, hlr.Network)
+	assert.Equal(t, "MyReference", hlr.Reference)
+	assert.Equal(t, "sent", hlr.Status)
 
-	if hlr.HRef != "https://rest.messagebird.com/hlr/27978c50354a93ca0ca8de6h54340177" {
-		t.Errorf("Unexpected HLR href: %s, expected: https://rest.messagebird.com/hlr/27978c50354a93ca0ca8de6h54340177", hlr.HRef)
-	}
+	assert.Equal(t, "2015-01-04T13:14:08Z", hlr.CreatedDatetime.Format(time.RFC3339))
+	assert.Equal(t, "2015-01-04T13:14:09Z", hlr.StatusDatetime.Format(time.RFC3339))
 
-	if hlr.MSISDN != 31612345678 {
-		t.Errorf("Unexpected HLR msisdn: %d, expected: 31612345678", hlr.MSISDN)
-	}
-
-	if hlr.Network != 20406 {
-		t.Errorf("Unexpected HLR network: %d, expected: 20406", hlr.Network)
-	}
-
-	if hlr.Reference != "MyReference" {
-		t.Errorf("Unexpected HLR reference: %s, expected: MyReference", hlr.Reference)
-	}
-
-	if hlr.Status != "sent" {
-		t.Errorf("Unexpected HLR status: %s, expected: sent", hlr.Status)
-	}
-
-	if hlr.CreatedDatetime == nil || hlr.CreatedDatetime.Format(time.RFC3339) != "2015-01-04T13:14:08Z" {
-		t.Errorf("Unexpected HLR created datetime: %s, expected: 2015-01-04T13:14:08Z", hlr.CreatedDatetime.Format(time.RFC3339))
-	}
-
-	if hlr.StatusDatetime == nil || hlr.StatusDatetime.Format(time.RFC3339) != "2015-01-04T13:14:09Z" {
-		t.Errorf("Unexpected HLR status datetime: %s, expected: 2015-01-04T13:14:09Z", hlr.StatusDatetime.Format(time.RFC3339))
-	}
 }
 
 func TestRead(t *testing.T) {
@@ -52,26 +32,16 @@ func TestRead(t *testing.T) {
 	client := mbtest.Client(t)
 
 	hlr, err := Read(client, "27978c50354a93ca0ca8de6h54340177")
-	if err != nil {
-		t.Fatalf("Didn't expect an error while requesting a HLR: %s", err)
-	}
+	assert.NoError(t, err)
 
 	assertHLRObject(t, hlr)
 }
 
 func TestRequestDataForHLR(t *testing.T) {
 	requestData, err := requestDataForHLR("31612345678", "MyReference")
-	if err != nil {
-		t.Fatalf("Didn't expect an error while getting the request data for a HLR: %s", err)
-	}
-
-	if requestData.MSISDN != "31612345678" {
-		t.Errorf("Unexpected msisdn: %s, expected: 31612345678", requestData.MSISDN)
-	}
-
-	if requestData.Reference != "MyReference" {
-		t.Errorf("Unexpected reference: %s, expected: MyReference", requestData.Reference)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "31612345678", requestData.MSISDN)
+	assert.Equal(t, "MyReference", requestData.Reference)
 }
 
 func TestCreate(t *testing.T) {
@@ -79,9 +49,7 @@ func TestCreate(t *testing.T) {
 	client := mbtest.Client(t)
 
 	hlr, err := Create(client, "31612345678", "MyReference")
-	if err != nil {
-		t.Fatalf("Didn't expect an error while creating a new HLR: %s", err)
-	}
+	assert.NoError(t, err)
 
 	assertHLRObject(t, hlr)
 }
@@ -93,21 +61,10 @@ func TestHLRError(t *testing.T) {
 	_, err := Read(client, "dummy_hlr_id")
 
 	errorResponse, ok := err.(messagebird.ErrorResponse)
-	if !ok {
-		t.Fatalf("Expected ErrorResponse to be returned, instead I got %s", err)
-	}
-
-	if len(errorResponse.Errors) != 1 {
-		t.Fatalf("Unexpected number of errors: %d, expected: 1", len(errorResponse.Errors))
-	}
-
-	if errorResponse.Errors[0].Code != 2 {
-		t.Errorf("Unexpected error code: %d, expected: 2", errorResponse.Errors[0].Code)
-	}
-
-	if errorResponse.Errors[0].Parameter != "access_key" {
-		t.Errorf("Unexpected error parameter: %s, expected: access_key", errorResponse.Errors[0].Parameter)
-	}
+	assert.True(t, ok)
+	assert.Len(t, errorResponse.Errors, 1)
+	assert.Equal(t, 2, errorResponse.Errors[0].Code)
+	assert.Equal(t, "access_key", errorResponse.Errors[0].Parameter)
 }
 
 func TestList(t *testing.T) {
@@ -115,22 +72,11 @@ func TestList(t *testing.T) {
 	client := mbtest.Client(t)
 
 	hlrList, err := List(client)
-	if err != nil {
-		t.Fatalf("Didn't expect an error while requesting HLRs: %s", err)
-	}
-
-	if hlrList.Offset != 0 {
-		t.Errorf("Unexpected result for the HLRList offset: %d, expected: 0", hlrList.Offset)
-	}
-	if hlrList.Limit != 20 {
-		t.Errorf("Unexpected result for the HLRList limit: %d, expected: 20", hlrList.Limit)
-	}
-	if hlrList.Count != 2 {
-		t.Errorf("Unexpected result for the HLRList count: %d, expected: 2", hlrList.Count)
-	}
-	if hlrList.TotalCount != 2 {
-		t.Errorf("Unexpected result for the HLRList total count: %d, expected: 2", hlrList.TotalCount)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 0, hlrList.Offset)
+	assert.Equal(t, 20, hlrList.Limit)
+	assert.Equal(t, 2, hlrList.Count)
+	assert.Equal(t, 2, hlrList.TotalCount)
 
 	for _, hlr := range hlrList.Items {
 		assertHLRObject(t, &hlr)

--- a/internal/mbtest/helper.go
+++ b/internal/mbtest/helper.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const testdataDir = "testdata"
@@ -15,9 +17,7 @@ func Testdata(t *testing.T, relativePath string) []byte {
 	path := filepath.Join(testdataDir, relativePath)
 
 	b, err := ioutil.ReadFile(path)
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
+	assert.NoError(t, err)
 
 	return b
 }
@@ -28,19 +28,14 @@ func AssertTestdata(t *testing.T, relativePath string, actual []byte) {
 	expected := bytes.TrimSpace(Testdata(t, relativePath))
 	actual = bytes.TrimSpace(actual)
 
-	if !bytes.Equal(expected, actual) {
-		t.Fatalf("expected %s, got %s", expected, actual)
-	}
+	assert.Truef(t, bytes.Equal(expected, actual), "expected %s, got %s", expected, actual)
 }
 
 // AssertEndpointCalled fails the test if the last request was not made to the
 // provided endpoint (e.g. combination of HTTP method and path).
 func AssertEndpointCalled(t *testing.T, method, path string) {
-	if Request.Method != method {
-		t.Fatalf("expected %s, got %s", method, Request.Method)
-	}
+	assert.Equal(t, method, Request.Method)
 
-	if escapedPath := Request.URL.EscapedPath(); escapedPath != path {
-		t.Fatalf("expected %s, got %s", path, escapedPath)
-	}
+	escapedPath := Request.URL.EscapedPath()
+	assert.Equal(t, path, escapedPath)
 }

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/messagebird/go-rest-api/v6/hlr"
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -19,44 +20,20 @@ func TestRead(t *testing.T) {
 
 	phoneNumber := "31624971134"
 	lookup, err := Read(client, phoneNumber, &Params{CountryCode: "NL"})
-	if err != nil {
-		t.Fatalf("Didn't expect error while doing the lookup: %s", err)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "https://rest.messagebird.com/lookup/31624971134", lookup.Href)
 
-	if lookup.Href != "https://rest.messagebird.com/lookup/31624971134" {
-		t.Errorf("Unexpected lookup href: %s", lookup.Href)
-	}
+	assert.Equal(t, phoneNumber, strconv.FormatInt(lookup.PhoneNumber, 10))
+	assert.Equal(t, "+31 6 24971134", lookup.Formats.International)
 
-	if strconv.FormatInt(lookup.PhoneNumber, 10) != phoneNumber {
-		t.Errorf("Unexpected lookup phoneNumber: %d", lookup.PhoneNumber)
-	}
-
-	if lookup.Formats.International != "+31 6 24971134" {
-		t.Errorf("Unexpected International format: %s", lookup.HLR.Reference)
-	}
-
-	if lookup.HLR != nil {
-		if lookup.HLR.Reference != "referece2000" {
-			t.Errorf("Unexpected hlr reference: %s", lookup.HLR.Reference)
-		}
-	} else {
-		t.Errorf("Unexpected empty hlr")
-	}
+	assert.Equal(t, "referece2000", lookup.HLR.Reference)
 }
 
 func checkHLR(t *testing.T, hlr *hlr.HLR) {
-	if hlr.ID != "6118d3f06566fcd0cdc8962h65065907" {
-		t.Errorf("Unexpected hlr id: %s", hlr.ID)
-	}
-	if hlr.Network != 20416 {
-		t.Errorf("Unexpected hlr network: %d", hlr.Network)
-	}
-	if hlr.Reference != "referece2000" {
-		t.Errorf("Unexpected hlr reference: %s", hlr.Reference)
-	}
-	if hlr.Status != "active" {
-		t.Errorf("Unexpected hlr status: %s", hlr.Status)
-	}
+	assert.Equal(t, "6118d3f06566fcd0cdc8962h65065907", hlr.ID)
+	assert.Equal(t, 20416, hlr.Network)
+	assert.Equal(t, "referece2000", hlr.Reference)
+	assert.Equal(t, "active", hlr.Status)
 }
 
 func TestReadHLR(t *testing.T) {
@@ -64,9 +41,7 @@ func TestReadHLR(t *testing.T) {
 	client := mbtest.Client(t)
 
 	hlr, err := ReadHLR(client, "31624971134", &Params{CountryCode: "NL"})
-	if err != nil {
-		t.Fatalf("Didn't expect error while doing the lookup: %s", err)
-	}
+	assert.NoError(t, err)
 	checkHLR(t, hlr)
 }
 
@@ -76,13 +51,8 @@ func TestRequestDataForLookupHLR(t *testing.T) {
 		Reference:   "MyReference",
 	}
 	request := requestDataForLookup(lookupParams)
-
-	if request.CountryCode != "NL" {
-		t.Errorf("Unexpected country code: %s, expected: NL", request.CountryCode)
-	}
-	if request.Reference != "MyReference" {
-		t.Errorf("Unexpected reference: %s, expected: MyReference", request.Reference)
-	}
+	assert.Equal(t, "NL", request.CountryCode)
+	assert.Equal(t, "MyReference", request.Reference)
 }
 
 func TestCreateHLR(t *testing.T) {
@@ -90,9 +60,7 @@ func TestCreateHLR(t *testing.T) {
 	client := mbtest.Client(t)
 
 	hlr, err := CreateHLR(client, "31624971134", &Params{CountryCode: "NL", Reference: "reference2000"})
-	if err != nil {
-		t.Fatalf("Didn't expect error while doing the lookup: %s", err)
-	}
+	assert.NoError(t, err)
 
 	checkHLR(t, hlr)
 }

--- a/number/number_test.go
+++ b/number/number_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -22,19 +23,13 @@ func TestSearch(t *testing.T) {
 		Type:          "mobile",
 		SearchPattern: NumberPatternEnd,
 	})
-	if err != nil {
-		t.Fatalf("unexpected error searching Numbers: %s", err)
-	}
-
-	if numLis.Items[0].Country != "NL" {
-		t.Errorf("got %s, expected NL", numLis.Items[0].Country)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "NL", numLis.Items[0].Country)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/available-phone-numbers/NL")
 
-	if query := mbtest.Request.URL.RawQuery; query != "features=sms&features=voice&limit=10&search_pattern=end&type=mobile" {
-		t.Fatalf("got %s, expected features=sms&features=voice&limit=10&search_pattern=end&type=mobile", query)
-	}
+	query := mbtest.Request.URL.RawQuery
+	assert.Equal(t, "features=sms&features=voice&limit=10&search_pattern=end&type=mobile", query)
 }
 
 func TestList(t *testing.T) {
@@ -42,19 +37,13 @@ func TestList(t *testing.T) {
 	client := mbtest.Client(t)
 
 	numLis, err := List(client, &NumberListParams{Limit: 10})
-	if err != nil {
-		t.Fatalf("unexpected error searching Numbers: %s", err)
-	}
-
-	if numLis.Items[0].Country != "NL" {
-		t.Errorf("got %s, expected NL", numLis.Items[0].Country)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "NL", numLis.Items[0].Country)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/phone-numbers")
 
-	if query := mbtest.Request.URL.RawQuery; query != "limit=10" {
-		t.Fatalf("got %s, expected limit=10", query)
-	}
+	query := mbtest.Request.URL.RawQuery
+	assert.Equal(t, "limit=10", query)
 }
 
 func TestRead(t *testing.T) {
@@ -62,13 +51,8 @@ func TestRead(t *testing.T) {
 	client := mbtest.Client(t)
 
 	num, err := Read(client, "31612345670")
-	if err != nil {
-		t.Fatalf("unexpected error searching Numbers: %s", err)
-	}
-
-	if num.Number != "31612345670" {
-		t.Fatalf("got %s, expected 31612345670", num.Number)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "31612345670", num.Number)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/phone-numbers/31612345670")
 }
@@ -77,9 +61,8 @@ func TestDelete(t *testing.T) {
 	mbtest.WillReturn([]byte(""), http.StatusNoContent)
 	client := mbtest.Client(t)
 
-	if err := Delete(client, "31612345670"); err != nil {
-		t.Errorf("unexpected error canceling Number: %s", err)
-	}
+	err := Delete(client, "31612345670")
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodDelete, "/v1/phone-numbers/31612345670")
 }
@@ -92,10 +75,7 @@ func TestUpdate(t *testing.T) {
 	number, err := Update(client, "31612345670", &NumberUpdateRequest{
 		Tags: []string{"tag1", "tag2", "tag3"},
 	})
-
-	if err != nil {
-		t.Errorf("unexpected error updating Number: %s", err)
-	}
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPatch, "/v1/phone-numbers/31612345670")
 	mbtest.AssertTestdata(t, "numberUpdateRequestObject.json", mbtest.Request.Body)
@@ -114,18 +94,10 @@ func TestPurchase(t *testing.T) {
 		Country:               "NL",
 		BillingIntervalMonths: 1,
 	})
-	if err != nil {
-		t.Errorf("unexpected error creating Number: %s", err)
-	}
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPost, "/v1/phone-numbers")
 	mbtest.AssertTestdata(t, "numberCreateRequestObject.json", mbtest.Request.Body)
-
-	if number.Number != "31971234567" {
-		t.Errorf("Unexpected number message id: %s, expected: 31971234567", number.Number)
-	}
-
-	if number.Country != "NL" {
-		t.Errorf("Unexpected number country: %s, expected: NL", number.Country)
-	}
+	assert.Equal(t, "31971234567", number.Number)
+	assert.Equal(t, "NL", number.Country)
 }

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const testTs = "1544544948"
@@ -76,13 +78,9 @@ func TestCalculateSignature(t *testing.T) {
 	for _, tt := range cases {
 		v := NewValidator(tt.sKey)
 		s, err := v.calculateSignature(tt.ts, tt.qp, []byte(tt.b))
-		if err != nil {
-			t.Errorf("Error calculating signature: %s, expected: %s", s, tt.es)
-		}
+		assert.NoError(t, err)
 		drs, _ := base64.StdEncoding.DecodeString(tt.es)
-		if bytes.Equal(s, drs) != tt.e {
-			t.Errorf("Unexpected signature: %s, test case: %s", s, tt.name)
-		}
+		assert.Equal(t, tt.e, bytes.Equal(s, drs))
 	}
 }
 func TestValidTimestamp(t *testing.T) {
@@ -123,9 +121,7 @@ func TestValidTimestamp(t *testing.T) {
 	for _, tt := range cases {
 		v := NewValidator(testKey)
 		r := v.validTimestamp(tt.ts)
-		if r != tt.e {
-			t.Errorf("Unexpected error validating ts: %s, test case: %s", tt.ts, tt.name)
-		}
+		assert.Equal(t, tt.e, r)
 	}
 }
 
@@ -168,9 +164,7 @@ func TestValidSignature(t *testing.T) {
 		v := NewValidator(testKey)
 		ValidityWindow = time.Hour * 100000
 		r := v.validSignature(tt.ts, tt.qp, []byte(tt.b), tt.s)
-		if r != tt.e {
-			t.Errorf("Unexpected error validating signature: %s, test case: %s", tt.s, tt.name)
-		}
+		assert.Equal(t, tt.e, r)
 	}
 }
 func TestValidate(t *testing.T) {
@@ -253,9 +247,7 @@ func TestValidate(t *testing.T) {
 		req.Header.Set(tt.sh, tt.s)
 		req.Header.Set(tt.tsh, tt.ts)
 		res, _ := client.Do(req)
-		if res.StatusCode != tt.e {
-			t.Errorf("Unexpected response code: %s, test case: %s", res.Status, tt.name)
-		}
+		assert.Equal(t, tt.e, res.StatusCode)
 	}
 
 }

--- a/sms/message_test.go
+++ b/sms/message_test.go
@@ -8,6 +8,7 @@ import (
 
 	messagebird "github.com/messagebird/go-rest-api/v6"
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -15,81 +16,29 @@ func TestMain(m *testing.M) {
 }
 
 func assertMessageObject(t *testing.T, message *Message) {
-	if message.ID != "6fe65f90454aa61536e6a88b88972670" {
-		t.Errorf("Unexpected message id: %s, expected: 6fe65f90454aa61536e6a88b88972670", message.ID)
-	}
-
-	if message.HRef != "https://rest.messagebird.com/messages/6fe65f90454aa61536e6a88b88972670" {
-		t.Errorf("Unexpected message href: %s, expected: https://rest.messagebird.com/messages/6fe65f90454aa61536e6a88b88972670", message.HRef)
-	}
-
-	if message.Direction != "mt" {
-		t.Errorf("Unexpected message direction: %s, expected: mt", message.Direction)
-	}
-
-	if message.Type != "sms" {
-		t.Errorf("Unexpected message type: %s, expected: sms", message.Type)
-	}
-
-	if message.Originator != "TestName" {
-		t.Errorf("Unexpected message originator: %s, expected: TestName", message.Originator)
-	}
-
-	if message.Body != "Hello World" {
-		t.Errorf("Unexpected message body: %s, expected: Hello World", message.Body)
-	}
-
-	if message.Reference != "" {
-		t.Errorf("Unexpected message reference: %s, expected: \"\"", message.Reference)
-	}
-
-	if message.Validity != nil {
-		t.Errorf("Unexpected message validity: %d, expected: nil", *message.Validity)
-	}
-
-	if message.Gateway != 239 {
-		t.Errorf("Unexpected message gateway: %d, expected: 239", message.Gateway)
-	}
-
-	if len(message.TypeDetails) != 0 {
-		t.Errorf("Unexpected number of items in message typedetails: %d, expected: 0", len(message.TypeDetails))
-	}
-
-	if message.DataCoding != "plain" {
-		t.Errorf("Unexpected message datacoding: %s, expected: plain", message.DataCoding)
-	}
-
-	if message.MClass != 1 {
-		t.Errorf("Unexpected message mclass: %d, expected: 1", message.MClass)
-	}
-
-	if message.ScheduledDatetime != nil {
-		t.Errorf("Unexpected message scheduled datetime: %s, expected: nil", message.ScheduledDatetime)
-	}
+	assert.Equal(t, "6fe65f90454aa61536e6a88b88972670", message.ID)
+	assert.Equal(t, "https://rest.messagebird.com/messages/6fe65f90454aa61536e6a88b88972670", message.HRef)
+	assert.Equal(t, "mt", message.Direction)
+	assert.Equal(t, "sms", message.Type)
+	assert.Equal(t, "TestName", message.Originator)
+	assert.Equal(t, "Hello World", message.Body)
+	assert.Equal(t, "", message.Reference)
+	assert.Nil(t, message.Validity)
+	assert.Equal(t, 239, message.Gateway)
+	assert.Len(t, message.TypeDetails, 0)
+	assert.Equal(t, "plain", message.DataCoding)
+	assert.Equal(t, 1, message.MClass)
+	assert.Nil(t, message.ScheduledDatetime)
 
 	if message.CreatedDatetime == nil || message.CreatedDatetime.Format(time.RFC3339) != "2015-01-05T10:02:59Z" {
 		t.Errorf("Unexpected message created datetime: %s, expected: 2015-01-05T10:02:59Z", message.CreatedDatetime)
 	}
+	assert.Equal(t, 1, message.Recipients.TotalCount)
+	assert.Equal(t, 1, message.Recipients.TotalSentCount)
+	assert.Equal(t, int64(31612345678), message.Recipients.Items[0].Recipient)
+	assert.Equal(t, "sent", message.Recipients.Items[0].Status)
 
-	if message.Recipients.TotalCount != 1 {
-		t.Fatalf("Unexpected number of total count: %d, expected: 1", message.Recipients.TotalCount)
-	}
-
-	if message.Recipients.TotalSentCount != 1 {
-		t.Errorf("Unexpected number of total sent count: %d, expected: 1", message.Recipients.TotalSentCount)
-	}
-
-	if message.Recipients.Items[0].Recipient != 31612345678 {
-		t.Errorf("Unexpected message recipient: %d, expected: 31612345678", message.Recipients.Items[0].Recipient)
-	}
-
-	if message.Recipients.Items[0].Status != "sent" {
-		t.Errorf("Unexpected message recipient status: %s, expected: sent", message.Recipients.Items[0].Status)
-	}
-
-	if message.Recipients.Items[0].StatusDatetime == nil || message.Recipients.Items[0].StatusDatetime.Format(time.RFC3339) != "2015-01-05T10:02:59Z" {
-		t.Errorf("Unexpected datetime status for message recipient: %s, expected: 2015-01-05T10:02:59Z", message.Recipients.Items[0].StatusDatetime.Format(time.RFC3339))
-	}
+	assert.Equal(t, "2015-01-05T10:02:59Z", message.Recipients.Items[0].StatusDatetime.Format(time.RFC3339))
 }
 
 func TestCreate(t *testing.T) {
@@ -97,9 +46,7 @@ func TestCreate(t *testing.T) {
 	client := mbtest.Client(t)
 
 	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", nil)
-	if err != nil {
-		t.Fatalf("Didn't expect error while creating a new message: %s", err)
-	}
+	assert.NoError(t, err)
 
 	assertMessageObject(t, message)
 }
@@ -111,21 +58,10 @@ func TestCreateError(t *testing.T) {
 	_, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", nil)
 
 	errorResponse, ok := err.(messagebird.ErrorResponse)
-	if !ok {
-		t.Fatalf("Expected ErrorResponse to be returned, instead I got %s", err)
-	}
-
-	if len(errorResponse.Errors) != 1 {
-		t.Fatalf("Unexpected number of errors: %d, expected: 1", len(errorResponse.Errors))
-	}
-
-	if errorResponse.Errors[0].Code != 2 {
-		t.Errorf("Unexpected error code: %d, expected: 2", errorResponse.Errors[0].Code)
-	}
-
-	if errorResponse.Errors[0].Parameter != "access_key" {
-		t.Errorf("Unexpected error parameter: %s, expected: access_key", errorResponse.Errors[0].Parameter)
-	}
+	assert.True(t, ok)
+	assert.Equal(t, 1, len(errorResponse.Errors))
+	assert.Equal(t, 2, errorResponse.Errors[0].Code)
+	assert.Equal(t, "access_key", errorResponse.Errors[0].Parameter)
 }
 
 func TestCreateWithParams(t *testing.T) {
@@ -141,29 +77,12 @@ func TestCreateWithParams(t *testing.T) {
 	}
 
 	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", params)
-	if err != nil {
-		t.Fatalf("Didn't expect error while creating a new message: %s", err)
-	}
-
-	if message.Type != "sms" {
-		t.Errorf("Unexpected message type: %s, expected: sms", message.Type)
-	}
-
-	if message.Reference != "TestReference" {
-		t.Errorf("Unexpected message reference: %s, expected: TestReference", message.Reference)
-	}
-
-	if *message.Validity != 13 {
-		t.Errorf("Unexpected message validity: %d, expected: 13", *message.Validity)
-	}
-
-	if message.Gateway != 10 {
-		t.Errorf("Unexpected message gateway: %d, expected: 10", message.Gateway)
-	}
-
-	if message.DataCoding != "unicode" {
-		t.Errorf("Unexpected message datacoding: %s, expected: unicode", message.DataCoding)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "sms", message.Type)
+	assert.Equal(t, "TestReference", message.Reference)
+	assert.Equal(t, 13, *message.Validity)
+	assert.Equal(t, 10, message.Gateway)
+	assert.Equal(t, "unicode", message.DataCoding)
 }
 
 func TestCreateWithBinaryType(t *testing.T) {
@@ -176,21 +95,10 @@ func TestCreateWithBinaryType(t *testing.T) {
 	}
 
 	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", params)
-	if err != nil {
-		t.Fatalf("Didn't expect error while creating a new message: %s", err)
-	}
-
-	if message.Type != "binary" {
-		t.Errorf("Unexpected message type: %s, expected: binary", message.Type)
-	}
-
-	if len(message.TypeDetails) != 1 {
-		t.Fatalf("Unexpected number of message typedetails: %d, expected: 1", len(message.TypeDetails))
-	}
-
-	if message.TypeDetails["udh"] != "050003340201" {
-		t.Errorf("Unexpected 'udh' value in message typedetails: %s, expected: 050003340201", message.TypeDetails["udh"])
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "binary", message.Type)
+	assert.Len(t, message.TypeDetails, 1)
+	assert.Equal(t, "050003340201", message.TypeDetails["udh"])
 }
 
 func TestCreateWithPremiumType(t *testing.T) {
@@ -203,29 +111,12 @@ func TestCreateWithPremiumType(t *testing.T) {
 	}
 
 	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", params)
-	if err != nil {
-		t.Fatalf("Didn't expect error while creating a new message: %s", err)
-	}
-
-	if message.Type != "premium" {
-		t.Errorf("Unexpected message type: %s, expected: premium", message.Type)
-	}
-
-	if len(message.TypeDetails) != 3 {
-		t.Fatalf("Unexpected number of message typedetails: %d, expected: 3", len(message.TypeDetails))
-	}
-
-	if message.TypeDetails["tariff"] != 150.0 {
-		t.Errorf("Unexpected 'tariff' value in message typedetails: %d, expected: 150.0", message.TypeDetails["tariff"])
-	}
-
-	if message.TypeDetails["shortcode"] != 1008.0 {
-		t.Errorf("Unexpected 'shortcode' value in message typedetails: %d, expected: 1008.0", message.TypeDetails["shortcode"])
-	}
-
-	if message.TypeDetails["keyword"] != "RESTAPI" {
-		t.Errorf("Unexpected 'keyword' value in message typedetails: %s, expected: RESTAPI", message.TypeDetails["keyword"])
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "premium", message.Type)
+	assert.Equal(t, 3, len(message.TypeDetails))
+	assert.Equal(t, 150.0, message.TypeDetails["tariff"])
+	assert.Equal(t, 1008.0, message.TypeDetails["shortcode"])
+	assert.Equal(t, "RESTAPI", message.TypeDetails["keyword"])
 }
 
 func TestCreateWithFlashType(t *testing.T) {
@@ -235,13 +126,8 @@ func TestCreateWithFlashType(t *testing.T) {
 	params := &Params{Type: "flash"}
 
 	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", params)
-	if err != nil {
-		t.Fatalf("Didn't expect error while creating a new message: %s", err)
-	}
-
-	if message.Type != "flash" {
-		t.Errorf("Unexpected message type: %s, expected: flash", message.Type)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "flash", message.Type)
 }
 
 func TestCreateWithScheduledDatetime(t *testing.T) {
@@ -253,33 +139,13 @@ func TestCreateWithScheduledDatetime(t *testing.T) {
 	params := &Params{ScheduledDatetime: scheduledDatetime}
 
 	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", params)
-	if err != nil {
-		t.Fatalf("Didn't expect error while creating a new message: %s", err)
-	}
-
-	if message.ScheduledDatetime.Format(time.RFC3339) != scheduledDatetime.Format(time.RFC3339) {
-		t.Errorf("Unexpected message scheduled datetime: %s, expected: %s", message.ScheduledDatetime.Format(time.RFC3339), scheduledDatetime.Format(time.RFC3339))
-	}
-
-	if message.Recipients.TotalCount != 1 {
-		t.Fatalf("Unexpected number of total count: %d, expected: 1", message.Recipients.TotalCount)
-	}
-
-	if message.Recipients.TotalSentCount != 0 {
-		t.Errorf("Unexpected number of total sent count: %d, expected: 0", message.Recipients.TotalSentCount)
-	}
-
-	if message.Recipients.Items[0].Recipient != 31612345678 {
-		t.Errorf("Unexpected message recipient: %d, expected: 31612345678", message.Recipients.Items[0].Recipient)
-	}
-
-	if message.Recipients.Items[0].Status != "scheduled" {
-		t.Errorf("Unexpected message recipient status: %s, expected: scheduled", message.Recipients.Items[0].Status)
-	}
-
-	if message.Recipients.Items[0].StatusDatetime != nil {
-		t.Errorf("Unexpected datetime status for message recipient: %s, expected: nil", message.Recipients.Items[0].StatusDatetime.Format(time.RFC3339))
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, scheduledDatetime.Format(time.RFC3339), message.ScheduledDatetime.Format(time.RFC3339))
+	assert.Equal(t, 1, message.Recipients.TotalCount)
+	assert.Equal(t, 0, message.Recipients.TotalSentCount)
+	assert.Equal(t, int64(31612345678), message.Recipients.Items[0].Recipient)
+	assert.Equal(t, "scheduled", message.Recipients.Items[0].Status)
+	assert.Nil(t, message.Recipients.Items[0].StatusDatetime)
 }
 
 func TestList(t *testing.T) {
@@ -287,22 +153,11 @@ func TestList(t *testing.T) {
 	client := mbtest.Client(t)
 
 	messageList, err := List(client, nil)
-	if err != nil {
-		t.Fatalf("Didn't expect an error while requesting Messages: %s", err)
-	}
-
-	if messageList.Offset != 0 {
-		t.Errorf("Unexpected result for the MessageList offset: %d, expected: 0", messageList.Offset)
-	}
-	if messageList.Limit != 20 {
-		t.Errorf("Unexpected result for the MessageList limit: %d, expected: 20", messageList.Limit)
-	}
-	if messageList.Count != 2 {
-		t.Errorf("Unexpected result for the MessageList count: %d, expected: 2", messageList.Count)
-	}
-	if messageList.TotalCount != 2 {
-		t.Errorf("Unexpected result for the MessageList total count: %d, expected: 2", messageList.TotalCount)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 0, messageList.Offset)
+	assert.Equal(t, 20, messageList.Limit)
+	assert.Equal(t, 2, messageList.Count)
+	assert.Equal(t, 2, messageList.TotalCount)
 
 	for _, message := range messageList.Items {
 		assertMessageObject(t, &message)
@@ -315,9 +170,8 @@ func TestListScheduled(t *testing.T) {
 		if !strings.Contains(r.URL.String(), expectedStatusFilter) {
 			t.Errorf("API call should contain filter by status (%v), but is is not %v", expectedStatusFilter, r.URL.String())
 		}
-		if _, err := w.Write(mbtest.Testdata(t, "messageListScheduledObject.json")); err != nil {
-			t.Fatalf("unexpected error responding to list scheduled request. err: %s", err)
-		}
+		_, err := w.Write(mbtest.Testdata(t, "messageListScheduledObject.json"))
+		assert.NoError(t, err)
 	})
 	transport, teardown := mbtest.HTTPTestTransport(h)
 	defer teardown()
@@ -326,18 +180,10 @@ func TestListScheduled(t *testing.T) {
 	client.HTTPClient.Transport = transport
 
 	messageList, err := List(client, &ListParams{Status: "scheduled"})
-	if err != nil {
-		t.Fatalf("Didn't expect an error while requesting Messages: %s", err)
-	}
-	if messageList.Count != 1 {
-		t.Errorf("Unexpected result for the MessageList count: %d, expected: 1", messageList.Count)
-	}
-	if messageList.TotalCount != 1 {
-		t.Errorf("Unexpected result for the MessageList total count: %d, expected: 1", messageList.TotalCount)
-	}
-	if len(messageList.Items) != 1 {
-		t.Errorf("Unexpected result for the MessageList number of items in list: %d, expected: 1", len(messageList.Items))
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 1, messageList.Count)
+	assert.Equal(t, 1, messageList.TotalCount)
+	assert.Len(t, messageList.Items, 1)
 }
 
 func TestRequestDataForMessage(t *testing.T) {
@@ -354,41 +200,16 @@ func TestRequestDataForMessage(t *testing.T) {
 	}
 
 	request, err := requestDataForMessage("MSGBIRD", []string{"31612345678"}, "MyBody", messageParams)
-	if err != nil {
-		t.Fatalf("Didn't expect error while getting request data for message: %s", err)
-	}
-
-	if request.Originator != "MSGBIRD" {
-		t.Errorf("Unexpected originator: %s, expected: MSGBIRD", request.Originator)
-	}
-	if request.Recipients[0] != "31612345678" {
-		t.Errorf("Unexpected recipient: %s, expected: 31612345678", request.Recipients[0])
-	}
-	if request.Body != "MyBody" {
-		t.Errorf("Unexpected body: %s, expected: MyBody", request.Body)
-	}
-	if request.Type != messageParams.Type {
-		t.Errorf("Unexpected type: %s, expected: %s", request.Type, messageParams.Type)
-	}
-	if request.Reference != messageParams.Reference {
-		t.Errorf("Unexpected reference: %s, expected: %s", request.Reference, messageParams.Reference)
-	}
-	if request.Validity != messageParams.Validity {
-		t.Errorf("Unexpected validity: %d, expected: %d", request.Validity, messageParams.Validity)
-	}
-	if request.Gateway != messageParams.Gateway {
-		t.Errorf("Unexpected gateway: %d, expected: %d", request.Gateway, messageParams.Gateway)
-	}
-	if request.TypeDetails != nil {
-		t.Errorf("Unexpected type details: %s, expected: nil", request.TypeDetails)
-	}
-	if request.DataCoding != messageParams.DataCoding {
-		t.Errorf("Unexpected data coding: %s, expected: %s", request.DataCoding, messageParams.DataCoding)
-	}
-	if request.ScheduledDatetime != messageParams.ScheduledDatetime.Format(time.RFC3339) {
-		t.Errorf("Unexepcted scheduled date time: %s, expected: %s", request.ScheduledDatetime, messageParams.ScheduledDatetime.Format(time.RFC3339))
-	}
-	if !request.ShortenURLs {
-		t.Errorf("Unexpected shorten URL flag: %v, expected: true", request.ShortenURLs)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "MSGBIRD", request.Originator)
+	assert.Equal(t, "31612345678", request.Recipients[0])
+	assert.Equal(t, "MyBody", request.Body)
+	assert.Equal(t, messageParams.Type, request.Type)
+	assert.Equal(t, messageParams.Reference, request.Reference)
+	assert.Equal(t, messageParams.Validity, request.Validity)
+	assert.Equal(t, messageParams.Gateway, request.Gateway)
+	assert.Nil(t, request.TypeDetails)
+	assert.Equal(t, messageParams.DataCoding, request.DataCoding)
+	assert.Equal(t, messageParams.ScheduledDatetime.Format(time.RFC3339), request.ScheduledDatetime)
+	assert.True(t, request.ShortenURLs)
 }

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -13,45 +14,18 @@ func TestMain(m *testing.M) {
 }
 
 func assertVerifyObject(t *testing.T, v *Verify) {
-	if v == nil {
-		t.Error("Got nil but expected valid object")
-	}
+	assert.NotNil(t, v)
+	assert.Equal(t, "15498233759288aaf929661v21936686", v.ID)
+	assert.Equal(t, "https://rest.messagebird.com/verify/15498233759288aaf929661v21936686", v.HRef)
+	assert.Equal(t, 31612345678, v.Recipient)
+	assert.Equal(t, "MyReference", v.Reference)
+	assert.Len(t, v.Messages, 1)
+	assert.Equal(t, "https://rest.messagebird.com/messages/c2bbd563759288aaf962910b56023756", v.Messages["href"])
+	assert.Equal(t, "sent", v.Status)
 
-	if v.ID != "15498233759288aaf929661v21936686" {
-		t.Errorf("Unexpected Verify ID: %s", v.ID)
-	}
+	assert.Equal(t, "2017-05-26T20:06:07Z", v.CreatedDatetime.Format(time.RFC3339))
 
-	if v.HRef != "https://rest.messagebird.com/verify/15498233759288aaf929661v21936686" {
-		t.Errorf("Unexpected HRef: %s", v.HRef)
-	}
-
-	if v.Recipient != 31612345678 {
-		t.Errorf("Unexpected Recipient: %d", v.Recipient)
-	}
-
-	if v.Reference != "MyReference" {
-		t.Errorf("Unexpected Reference: %s", v.Reference)
-	}
-
-	if len(v.Messages) != 1 {
-		t.Errorf("Got %d messages, expected 1", len(v.Messages))
-	}
-
-	if v.Messages["href"] != "https://rest.messagebird.com/messages/c2bbd563759288aaf962910b56023756" {
-		t.Errorf("Unexpected HRef value in messages: %s", v.Messages["href"])
-	}
-
-	if v.Status != "sent" {
-		t.Errorf("Unexpected status: %s", v.Status)
-	}
-
-	if v.CreatedDatetime == nil || v.CreatedDatetime.Format(time.RFC3339) != "2017-05-26T20:06:07Z" {
-		t.Errorf("Unexpected Verify created datetime: %s", v.CreatedDatetime.Format(time.RFC3339))
-	}
-
-	if v.ValidUntilDatetime == nil || v.ValidUntilDatetime.Format(time.RFC3339) != "2017-05-26T20:06:37Z" {
-		t.Errorf("Unexpected Verify valid until datetime: %s", v.ValidUntilDatetime.Format(time.RFC3339))
-	}
+	assert.Equal(t, "2017-05-26T20:06:37Z", v.ValidUntilDatetime.Format(time.RFC3339))
 }
 
 func TestCreate(t *testing.T) {
@@ -59,9 +33,7 @@ func TestCreate(t *testing.T) {
 	client := mbtest.Client(t)
 
 	v, err := Create(client, "31612345678", nil)
-	if err != nil {
-		t.Fatalf("Didn't expect an error while requesting a verification: %s", err)
-	}
+	assert.NoError(t, err)
 
 	assertVerifyObject(t, v)
 }
@@ -70,9 +42,8 @@ func TestDelete(t *testing.T) {
 	mbtest.WillReturn([]byte(""), http.StatusNoContent)
 	client := mbtest.Client(t)
 
-	if err := Delete(client, "15498233759288aaf929661v21936686"); err != nil {
-		t.Fatalf("unexpected error deleting Verify: %s", err)
-	}
+	err := Delete(client, "15498233759288aaf929661v21936686")
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodDelete, "/verify/15498233759288aaf929661v21936686")
 }
@@ -82,13 +53,8 @@ func TestRead(t *testing.T) {
 	client := mbtest.Client(t)
 
 	v, err := Read(client, "15498233759288aaf929661v21936686")
-	if err != nil {
-		t.Fatalf("unexpected error reading Verify: %s", err)
-	}
-
-	if v.ID != "15498233759288aaf929661v21936686" {
-		t.Fatalf("got %s, expected 15498233759288aaf929661v21936686", v.ID)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "15498233759288aaf929661v21936686", v.ID)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/verify/15498233759288aaf929661v21936686")
 }
@@ -98,53 +64,23 @@ func TestVerifyToken(t *testing.T) {
 	client := mbtest.Client(t)
 
 	v, err := VerifyToken(client, "does not", "matter")
-	if err != nil {
-		t.Fatalf("Didn't expect an error while verifying token: %s", err)
-	}
+	assert.NoError(t, err)
 
 	assertVerifyTokenObject(t, v)
 }
 
 func assertVerifyTokenObject(t *testing.T, v *Verify) {
-	if v == nil {
-		t.Error("Got nil but expected valid object")
-	}
+	assert.NotNil(t, v)
+	assert.Equal(t, "a3f2edb23592d68163f9694v13904556", v.ID)
+	assert.Equal(t, "https://rest.messagebird.com/verify/a3f2edb23592d68163f9694v13904556", v.HRef)
+	assert.Equal(t, 31612345678, v.Recipient)
+	assert.Equal(t, "MyReference", v.Reference)
+	assert.Len(t, v.Messages, 1)
+	assert.Equal(t, "https://rest.messagebird.com/messages/63b168423592d681641eb07b76226648", v.Messages["href"])
+	assert.Equal(t, "verified", v.Status)
 
-	if v.ID != "a3f2edb23592d68163f9694v13904556" {
-		t.Errorf("Unexpected Verify ID: %s", v.ID)
-	}
-
-	if v.HRef != "https://rest.messagebird.com/verify/a3f2edb23592d68163f9694v13904556" {
-		t.Errorf("Unexpected HRef: %s", v.HRef)
-	}
-
-	if v.Recipient != 31612345678 {
-		t.Errorf("Unexpected Recipient: %d", v.Recipient)
-	}
-
-	if v.Reference != "MyReference" {
-		t.Errorf("Unexpected Reference: %s", v.Reference)
-	}
-
-	if len(v.Messages) != 1 {
-		t.Errorf("Got %d messages, expected 1", len(v.Messages))
-	}
-
-	if v.Messages["href"] != "https://rest.messagebird.com/messages/63b168423592d681641eb07b76226648" {
-		t.Errorf("Unexpected HRef value in messages: %s", v.Messages["href"])
-	}
-
-	if v.Status != "verified" {
-		t.Errorf("Unexpected status: %s", v.Status)
-	}
-
-	if v.CreatedDatetime == nil || v.CreatedDatetime.Format(time.RFC3339) != "2017-05-30T12:39:50Z" {
-		t.Errorf("Unexpected Verify created datetime: %s", v.CreatedDatetime.Format(time.RFC3339))
-	}
-
-	if v.ValidUntilDatetime == nil || v.ValidUntilDatetime.Format(time.RFC3339) != "2017-05-30T12:40:20Z" {
-		t.Errorf("Unexpected Verify valid until datetime: %s", v.ValidUntilDatetime.Format(time.RFC3339))
-	}
+	assert.Equal(t, "2017-05-30T12:39:50Z", v.CreatedDatetime.Format(time.RFC3339))
+	assert.Equal(t, "2017-05-30T12:40:20Z", v.ValidUntilDatetime.Format(time.RFC3339))
 }
 
 func TestRequestDataForVerify(t *testing.T) {
@@ -162,38 +98,15 @@ func TestRequestDataForVerify(t *testing.T) {
 	}
 
 	requestData, err := requestDataForVerify("31612345678", verifyParams)
-	if err != nil {
-		t.Fatalf("Didn't expect error while getting request data for message: %s", err)
-	}
-
-	if requestData.Recipient != "31612345678" {
-		t.Errorf("Unexpected recipient: %s, expected: 31612345678", requestData.Recipient)
-	}
-	if requestData.Originator != "MSGBIRD" {
-		t.Errorf("Unexpected originator: %s, expected: MSGBIRD", requestData.Originator)
-	}
-	if requestData.Reference != "MyReference" {
-		t.Errorf("Unexpected reference: %s, expected: MyReference", requestData.Reference)
-	}
-	if requestData.Type != "sms" {
-		t.Errorf("Unexpected type: %s, expected: sms", requestData.Type)
-	}
-	if requestData.DataCoding != "plain" {
-		t.Errorf("Unexpected data coding: %s, expected: plain", requestData.DataCoding)
-	}
-	if requestData.ReportURL != "http://example.com/report" {
-		t.Errorf("Unexpected report URL: %s, expected: http://example.com/repot", requestData.ReportURL)
-	}
-	if requestData.Voice != "male" {
-		t.Errorf("Unexpected voice: %s, expected: male", requestData.Voice)
-	}
-	if requestData.Language != "en-gb" {
-		t.Errorf("Unexpected language: %s, expected en-gb", requestData.Language)
-	}
-	if requestData.Timeout != 20 {
-		t.Errorf("Unexepcted timeout: %d, expected 20", requestData.Timeout)
-	}
-	if requestData.TokenLength != 8 {
-		t.Errorf("Unexpected token length: %d, expected 8", requestData.TokenLength)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "31612345678", requestData.Recipient)
+	assert.Equal(t, "MSGBIRD", requestData.Originator)
+	assert.Equal(t, "MyReference", requestData.Reference)
+	assert.Equal(t, "sms", requestData.Type)
+	assert.Equal(t, "plain", requestData.DataCoding)
+	assert.Equal(t, "http://example.com/report", requestData.ReportURL)
+	assert.Equal(t, "male", requestData.Voice)
+	assert.Equal(t, "en-gb", requestData.Language)
+	assert.Equal(t, 20, requestData.Timeout)
+	assert.Equal(t, 8, requestData.TokenLength)
 }

--- a/voice/call_test.go
+++ b/voice/call_test.go
@@ -3,6 +3,8 @@ package voice
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInitiateCall(t *testing.T) {
@@ -27,9 +29,7 @@ func TestInitiateCall(t *testing.T) {
 		},
 	}
 	_, err := InitiateCall(client, source, destination, callflow, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 }
 
 func TestCallByID(t *testing.T) {
@@ -54,16 +54,10 @@ func TestCallByID(t *testing.T) {
 		},
 	}
 	call, err := InitiateCall(client, source, destination, callflow, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	time.Sleep(time.Second)
 	fetchedCall, err := CallByID(client, call.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if fetchedCall.Source != call.Source {
-		t.Fatalf("mismatched source: exp %q, got %q", call.Source, fetchedCall.Source)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, call.Source, fetchedCall.Source)
 }

--- a/voice/callflow_test.go
+++ b/voice/callflow_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func ExampleCallFlow() {
@@ -72,13 +74,10 @@ func TestCallFlowJSONMarshal(t *testing.T) {
 	}
 
 	jsonData, err := json.Marshal(referenceCallflow)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	var callflow CallFlow
-	if err := json.Unmarshal(jsonData, &callflow); err != nil {
-		t.Fatal(err)
-	}
+	unmarshallErr := json.Unmarshal(jsonData, &callflow)
+	assert.NoError(t, unmarshallErr)
 	if !reflect.DeepEqual(*referenceCallflow, callflow) {
 		t.Logf("exp: %#v", *referenceCallflow)
 		t.Logf("got: %#v", callflow)
@@ -158,9 +157,8 @@ func TestCallFlowJSONUnmarshal(t *testing.T) {
 	}
 
 	var callflow CallFlow
-	if err := json.Unmarshal([]byte(referenceJSON), &callflow); err != nil {
-		t.Fatal(err)
-	}
+	err := json.Unmarshal([]byte(referenceJSON), &callflow)
+	assert.NoError(t, err)
 	if !reflect.DeepEqual(*referenceCallflow, callflow) {
 		t.Logf("exp: %#v", *referenceCallflow)
 		t.Logf("got: %#v", callflow)
@@ -197,15 +195,10 @@ func TestCreateCallFlow(t *testing.T) {
 			},
 		},
 	}
-	if err := newCf.Create(mbClient); err != nil {
-		t.Fatal(err)
-	}
-	if newCf.Title != "the-title" {
-		t.Fatalf("Unexpected Title: %q", newCf.Title)
-	}
-	if len(newCf.Steps) != 3 {
-		t.Fatalf("Unexpected number of steps: %q", len(newCf.Steps))
-	}
+	err := newCf.Create(mbClient)
+	assert.NoError(t, err)
+	assert.Equal(t, "the-title", newCf.Title)
+	assert.Len(t, newCf.Steps, 3)
 }
 
 func TestCallFlowByID(t *testing.T) {
@@ -220,17 +213,12 @@ func TestCallFlowByID(t *testing.T) {
 			&CallFlowHangupStep{},
 		},
 	}
-	if err := newCf.Create(mbClient); err != nil {
-		t.Fatal(err)
-	}
+	err := newCf.Create(mbClient)
+	assert.NoError(t, err)
 
 	fetchedCf, err := CallFlowByID(mbClient, newCf.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if fetchedCf.ID != newCf.ID {
-		t.Fatalf("mismatched fetched IDs: exp %q, got %q", newCf.ID, fetchedCf.ID)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, newCf.ID, fetchedCf.ID)
 }
 
 func TestCallFlowList(t *testing.T) {
@@ -246,19 +234,15 @@ func TestCallFlowList(t *testing.T) {
 				&CallFlowHangupStep{},
 			},
 		}
-		if err := newCf.Create(mbClient); err != nil {
-			t.Fatal(err)
-		}
+		err := newCf.Create(mbClient)
+		assert.NoError(t, err)
 	}
 
 	i := 0
 	for cf := range CallFlows(mbClient).Stream() {
-		if err, ok := cf.(error); ok {
-			t.Fatal(err)
-		}
+		_, ok := cf.(error)
+		assert.False(t, ok)
 		i++
 	}
-	if i == 0 {
-		t.Fatal("no callflows were fetched")
-	}
+	assert.NotEqual(t, 0, i)
 }

--- a/voice/paginator_test.go
+++ b/voice/paginator_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPaginatorStream(t *testing.T) {
@@ -30,12 +32,10 @@ func TestPaginatorStream(t *testing.T) {
 	i := 0
 	for val := range pag.Stream() {
 		t.Logf("%d, %v", i+1, val)
-		if v, ok := val.(myStruct); !ok || v.Val != i+1 {
-			t.Fatalf("unexpected item at index %d: %#v", i, val)
-		}
+		v, ok := val.(myStruct)
+		assert.True(t, ok)
+		assert.Equal(t, i+1, v.Val)
 		i++
 	}
-	if i != 3 {
-		t.Fatalf("unexpected number of elements: %d", i)
-	}
+	assert.Equal(t, 3, i)
 }

--- a/voice/recording_test.go
+++ b/voice/recording_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRecordingGetFile(t *testing.T) {
@@ -20,13 +21,9 @@ func TestRecordingGetFile(t *testing.T) {
 		},
 	}
 	r, err := rec.DownloadFile(mbClient)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	wav, err := ioutil.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	if string(wav) != string(fileContents) {
 		t.Logf("exp: %q", string(fileContents))
 		t.Logf("got: %q", string(wav))
@@ -37,9 +34,8 @@ func TestRecordingGetFile(t *testing.T) {
 func TestDelete(t *testing.T) {
 	mbtest.WillReturn([]byte(""), http.StatusNoContent)
 	client := mbtest.Client(t)
-	if err := Delete(client, "callid", "legid", "recid"); err != nil {
-		t.Errorf("unexpected error while deleting recording: %s", err)
-	}
+	err := Delete(client, "callid", "legid", "recid")
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodDelete, "/v1/calls/callid/legs/legid/recordings/recid")
 }
@@ -49,19 +45,10 @@ func TestReadRecording(t *testing.T) {
 	client := mbtest.Client(t)
 
 	recording, err := ReadRecording(client, "callid", "legid", "recid")
-	if err != nil {
-		t.Fatalf("unexpected error read recording: %s", err)
-	}
-
-	if recording.ID != "recid" {
-		t.Fatalf("expect %s got %s", "recid", recording.ID)
-	}
-	if recording.LegID != "legid" {
-		t.Fatalf("expect %s got %s", "legid", recording.LegID)
-	}
-	if recording.Status != RecordingStatusDone {
-		t.Fatalf("expect %s got %s", RecordingStatusDone, recording.Status)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "recid", recording.ID)
+	assert.Equal(t, "legid", recording.LegID)
+	assert.Equal(t, RecordingStatusDone, recording.Status)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/calls/callid/legs/legid/recordings/recid")
 }
@@ -73,25 +60,13 @@ func TestRecordings(t *testing.T) {
 	paginator := Recordings(client, "callid", "legid")
 
 	data, err := paginator.NextPage()
-	if err != nil {
-		t.Fatalf("unexpected error read recording: %s", err)
-	}
+	assert.NoError(t, err)
 
 	recordings := data.([]Recording)
-
-	if len(recordings) != 2 {
-		t.Errorf("got %d recordings expect 1", len(recordings))
-	}
-
-	if recordings[0].ID != "recid" {
-		t.Errorf("expect %s got %s", "recid", recordings[0].ID)
-	}
-	if recordings[0].LegID != "legid" {
-		t.Errorf("expect %s got %s", "legid", recordings[0].LegID)
-	}
-	if recordings[0].Status != RecordingStatusDone {
-		t.Errorf("expect %s got %s", RecordingStatusDone, recordings[0].Status)
-	}
+	assert.Len(t, recordings, 2)
+	assert.Equal(t, "recid", recordings[0].ID)
+	assert.Equal(t, "legid", recordings[0].LegID)
+	assert.Equal(t, RecordingStatusDone, recordings[0].Status)
 
 	mbtest.AssertEndpointCalled(t, http.MethodGet, "/v1/calls/callid/legs/legid/recordings")
 }

--- a/voice/transcription_test.go
+++ b/voice/transcription_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -24,9 +25,7 @@ func TestTranscriptionGetContents(t *testing.T) {
 		},
 	}
 	contents, err := trans.Contents(mbClient)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	if contents != text {
 		t.Logf("exp: %q", text)
 		t.Logf("got: %q", contents)
@@ -40,9 +39,7 @@ func TestCreateTranscription(t *testing.T) {
 
 	callID, legID, recordingID := "7777777", "88888888", "999999999"
 	_, err := CreateTranscription(client, callID, legID, recordingID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	mbtest.AssertEndpointCalled(t, http.MethodPost, fmt.Sprintf("/v1/calls/%s/legs/%s/recordings/%s/transcriptions", callID, legID, recordingID))
 }

--- a/voice/voice_test.go
+++ b/voice/voice_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestErrorReader(t *testing.T) {
@@ -11,49 +12,27 @@ func TestErrorReader(t *testing.T) {
 		b := mbtest.Testdata(t, "error.json")
 		err := errorReader(b).(ErrorResponse)
 
-		if count := len(err.Errors); count != 1 {
-			t.Fatalf("Got %d, expected 1", count)
-		}
-
-		if err.Errors[0].Code != 13 {
-			t.Errorf("Got %d, expected 13", err.Errors[0].Code)
-		}
-		if err.Errors[0].Message != "some-error" {
-			t.Errorf("Got %q, expected some-error", err.Errors[0].Message)
-		}
+		assert.Len(t, err.Errors, 1)
+		assert.Equal(t, 13, err.Errors[0].Code)
+		assert.Equal(t, "some-error", err.Errors[0].Message)
 	})
 
 	t.Run("Multiple errors", func(t *testing.T) {
 		b := mbtest.Testdata(t, "errors.json")
 		err := errorReader(b).(ErrorResponse)
 
-		if count := len(err.Errors); count != 2 {
-			t.Fatalf("Got %d, expected 2", count)
-		}
-
-		if err.Errors[0].Code != 11 {
-			t.Errorf("Got %d, expected 11", err.Errors[0].Code)
-		}
-		if err.Errors[0].Message != "some-error" {
-			t.Errorf("Got %q, expected some-error", err.Errors[0].Message)
-		}
-		if err.Errors[1].Code != 15 {
-			t.Errorf("Got %d, expected 15", err.Errors[1].Code)
-		}
-		if err.Errors[1].Message != "other-error" {
-			t.Errorf("Got %q, expected other-error", err.Errors[1].Message)
-		}
+		assert.Len(t, err.Errors, 2)
+		assert.Equal(t, 11, err.Errors[0].Code)
+		assert.Equal(t, "some-error", err.Errors[0].Message)
+		assert.Equal(t, 15, err.Errors[1].Code)
+		assert.Equal(t, "other-error", err.Errors[1].Message)
 	})
 
 	t.Run("Invalid JSON", func(t *testing.T) {
 		b := []byte("clearly not json")
 		_, ok := errorReader(b).(ErrorResponse)
 
-		if ok {
-			// If the data b is not JSON, we expect a "generic" errorString
-			// (from fmt.Errorf), but we somehow got our own ErrorResponse back.
-			t.Fatalf("Got ErrorResponse, expected errorString")
-		}
+		assert.False(t, ok)
 	})
 }
 
@@ -72,7 +51,6 @@ func TestErrorResponseError(t *testing.T) {
 	}
 
 	expect := `code: 1, message: "foo"; code: 2, message: "bar"`
-	if actual := err.Error(); actual != expect {
-		t.Fatalf("Got %q, expected %q", actual, expect)
-	}
+	actual := err.Error()
+	assert.Equal(t, expect, actual)
 }

--- a/voice/webhook_test.go
+++ b/voice/webhook_test.go
@@ -2,6 +2,8 @@ package voice
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateWebhook(t *testing.T) {
@@ -12,12 +14,8 @@ func TestCreateWebhook(t *testing.T) {
 
 	const url = "https://example.com/voice-webhook"
 	newWh, err := CreateWebHook(mbClient, url, "token")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if newWh.URL != url {
-		t.Fatalf("Unexpected URL: %q", newWh.URL)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, url, newWh.URL)
 }
 
 func TestWebhookList(t *testing.T) {
@@ -27,19 +25,16 @@ func TestWebhookList(t *testing.T) {
 	}
 
 	for _, c := range []string{"foo", "bar", "baz"} {
-		if _, err := CreateWebHook(mbClient, "https://example/com/"+c, "token"); err != nil {
-			t.Fatal(err)
-		}
+		_, err := CreateWebHook(mbClient, "https://example/com/"+c, "token")
+		assert.NoError(t, err)
 	}
 
 	i := 0
 	for cf := range Webhooks(mbClient).Stream() {
-		if err, ok := cf.(error); ok {
-			t.Fatal(err)
-		}
+		err, ok := cf.(error)
+		assert.NoError(t, err)
+		assert.True(t, ok)
 		i++
 	}
-	if i == 0 {
-		t.Fatal("no webhooks were fetched")
-	}
+	assert.Equal(t, 0, i)
 }

--- a/voicemessage/voice_message_test.go
+++ b/voicemessage/voice_message_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/messagebird/go-rest-api/v6"
 	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -14,69 +15,25 @@ func TestMain(m *testing.M) {
 }
 
 func assertVoiceMessageObject(t *testing.T, message *VoiceMessage) {
-	if message.ID != "430c44a0354aab7ac9553f7a49907463" {
-		t.Errorf("Unexpected voice message id: %s, expected: 430c44a0354aab7ac9553f7a49907463", message.ID)
-	}
+	assert.Equal(t, "430c44a0354aab7ac9553f7a49907463", message.ID)
+	assert.Equal(t, "https://rest.messagebird.com/voicemessages/430c44a0354aab7ac9553f7a49907463", message.HRef)
+	assert.Equal(t, "MessageBird", message.Originator)
 
-	if message.HRef != "https://rest.messagebird.com/voicemessages/430c44a0354aab7ac9553f7a49907463" {
-		t.Errorf("Unexpected voice message href: %s, expected: https://rest.messagebird.com/voicemessages/430c44a0354aab7ac9553f7a49907463", message.HRef)
-	}
+	assert.Equal(t, "Hello World", message.Body)
+	assert.Equal(t, "", message.Reference)
+	assert.Equal(t, "en-gb", message.Language)
+	assert.Equal(t, "female", message.Voice)
+	assert.Equal(t, 1, message.Repeat)
+	assert.Equal(t, "continue", message.IfMachine)
+	assert.Nil(t, message.ScheduledDatetime)
 
-	if message.Originator != "MessageBird" {
-		t.Errorf("Unexpected voice message originator: %s, expected: MessageBird", message.Originator)
-	}
+	assert.Equal(t, "2015-01-05T16:11:24Z", message.CreatedDatetime.Format(time.RFC3339))
+	assert.Equal(t, 1, message.Recipients.TotalCount)
+	assert.Equal(t, 1, message.Recipients.TotalSentCount)
+	assert.Equal(t, int64(31612345678), message.Recipients.Items[0].Recipient)
+	assert.Equal(t, "calling", message.Recipients.Items[0].Status)
 
-	if message.Body != "Hello World" {
-		t.Errorf("Unexpected voice message body: %s, expected: Hello World", message.Body)
-	}
-
-	if message.Reference != "" {
-		t.Errorf("Unexpected voice message reference: %s, expected: \"\"", message.Reference)
-	}
-
-	if message.Language != "en-gb" {
-		t.Errorf("Unexpected voice message language: %s, expected: en-gb", message.Language)
-	}
-
-	if message.Voice != "female" {
-		t.Errorf("Unexpected voice message voice: %s, expected: female", message.Voice)
-	}
-
-	if message.Repeat != 1 {
-		t.Errorf("Unexpected voice message repeat: %d, expected: 1", message.Repeat)
-	}
-
-	if message.IfMachine != "continue" {
-		t.Errorf("Unexpected voice message ifmachine: %s, expected: continue", message.IfMachine)
-	}
-
-	if message.ScheduledDatetime != nil {
-		t.Errorf("Unexpected voice message scheduled datetime: %s, expected: nil", message.ScheduledDatetime)
-	}
-
-	if message.CreatedDatetime == nil || message.CreatedDatetime.Format(time.RFC3339) != "2015-01-05T16:11:24Z" {
-		t.Errorf("Unexpected voice message created datetime: %s, expected: 2015-01-05T16:11:24Z", message.CreatedDatetime.Format(time.RFC3339))
-	}
-
-	if message.Recipients.TotalCount != 1 {
-		t.Fatalf("Unexpected number of total count: %d, expected: 1", message.Recipients.TotalCount)
-	}
-
-	if message.Recipients.TotalSentCount != 1 {
-		t.Errorf("Unexpected number of total sent count: %d, expected: 1", message.Recipients.TotalSentCount)
-	}
-
-	if message.Recipients.Items[0].Recipient != 31612345678 {
-		t.Errorf("Unexpected voice message recipient: %d, expected: 31612345678", message.Recipients.Items[0].Recipient)
-	}
-
-	if message.Recipients.Items[0].Status != "calling" {
-		t.Errorf("Unexpected voice message recipient status: %s, expected: calling", message.Recipients.Items[0].Status)
-	}
-
-	if message.Recipients.Items[0].StatusDatetime == nil || message.Recipients.Items[0].StatusDatetime.Format(time.RFC3339) != "2015-01-05T16:11:24Z" {
-		t.Errorf("Unexpected datetime status for voice message recipient: %s, expected: 2015-01-05T16:11:24Z", message.Recipients.Items[0].StatusDatetime.Format(time.RFC3339))
-	}
+	assert.Equal(t, "2015-01-05T16:11:24Z", message.Recipients.Items[0].StatusDatetime.Format(time.RFC3339))
 
 }
 
@@ -86,10 +43,8 @@ func TestCreate(t *testing.T) {
 
 	message, err := Create(client, []string{"31612345678"}, "Hello World", nil)
 
-	errorResponse, ok := err.(messagebird.ErrorResponse)
-	if ok {
-		t.Errorf("Unexpected error returned with voiceMessage %#v", errorResponse)
-	}
+	_, ok := err.(messagebird.ErrorResponse)
+	assert.False(t, ok)
 
 	assertVoiceMessageObject(t, message)
 }
@@ -106,25 +61,11 @@ func TestCreateWithParams(t *testing.T) {
 	}
 
 	message, err := Create(client, []string{"31612345678"}, "Hello World", params)
-	if err != nil {
-		t.Fatalf("Didn't expect error while creating a new voice message: %s", err)
-	}
-
-	if message.Reference != "MyReference" {
-		t.Errorf("Unexpected voice message reference: %s, expected: MyReference", message.Reference)
-	}
-
-	if message.Voice != "male" {
-		t.Errorf("Unexpected voice message voice: %s, expected: male", message.Voice)
-	}
-
-	if message.Repeat != 5 {
-		t.Errorf("Unexpected voice message repeat: %d, expected: 5", message.Repeat)
-	}
-
-	if message.IfMachine != "hangup" {
-		t.Errorf("Unexpected voice message ifmachine: %s, expected: hangup", message.IfMachine)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "MyReference", message.Reference)
+	assert.Equal(t, "male", message.Voice)
+	assert.Equal(t, 5, message.Repeat)
+	assert.Equal(t, "hangup", message.IfMachine)
 }
 
 func TestCreateWithScheduledDatetime(t *testing.T) {
@@ -136,29 +77,12 @@ func TestCreateWithScheduledDatetime(t *testing.T) {
 	params := &Params{ScheduledDatetime: scheduledDatetime}
 
 	message, err := Create(client, []string{"31612345678"}, "Hello World", params)
-	if err != nil {
-		t.Fatalf("Didn't expect error while creating a new voice message: %s", err)
-	}
-
-	if message.ScheduledDatetime.Format(time.RFC3339) != scheduledDatetime.Format(time.RFC3339) {
-		t.Errorf("Unexpected scheduled datetime: %s, expected: %s", message.ScheduledDatetime.Format(time.RFC3339), scheduledDatetime.Format(time.RFC3339))
-	}
-
-	if message.Recipients.TotalCount != 1 {
-		t.Fatalf("Unexpected number of total count: %d, expected: 1", message.Recipients.TotalCount)
-	}
-
-	if message.Recipients.TotalSentCount != 0 {
-		t.Errorf("Unexpected number of total sent count: %d, expected: 0", message.Recipients.TotalSentCount)
-	}
-
-	if message.Recipients.Items[0].Recipient != 31612345678 {
-		t.Errorf("Unexpected voice message recipient: %d, expected: 31612345678", message.Recipients.Items[0].Recipient)
-	}
-
-	if message.Recipients.Items[0].Status != "scheduled" {
-		t.Errorf("Unexpected voice message recipient status: %s, expected: scheduled", message.Recipients.Items[0].Status)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, scheduledDatetime.Format(time.RFC3339), message.ScheduledDatetime.Format(time.RFC3339))
+	assert.Equal(t, 1, message.Recipients.TotalCount)
+	assert.Equal(t, 0, message.Recipients.TotalSentCount)
+	assert.Equal(t, int64(31612345678), message.Recipients.Items[0].Recipient)
+	assert.Equal(t, "scheduled", message.Recipients.Items[0].Status)
 }
 
 func TestList(t *testing.T) {
@@ -166,22 +90,11 @@ func TestList(t *testing.T) {
 	client := mbtest.Client(t)
 
 	messageList, err := List(client)
-	if err != nil {
-		t.Fatalf("Didn't expect an error while requesting VoiceMessages: %s", err)
-	}
-
-	if messageList.Offset != 0 {
-		t.Errorf("Unexpected result for the VoiceMessages offset: %d, expected: 0", messageList.Offset)
-	}
-	if messageList.Limit != 20 {
-		t.Errorf("Unexpected result for the VoiceMessages limit: %d, expected: 20", messageList.Limit)
-	}
-	if messageList.Count != 2 {
-		t.Errorf("Unexpected result for the VoiceMessages count: %d, expected: 2", messageList.Count)
-	}
-	if messageList.TotalCount != 2 {
-		t.Errorf("Unexpected result for the VoiceMessages total count: %d, expected: 2", messageList.TotalCount)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 0, messageList.Offset)
+	assert.Equal(t, 20, messageList.Limit)
+	assert.Equal(t, 2, messageList.Count)
+	assert.Equal(t, 2, messageList.TotalCount)
 
 	for _, message := range messageList.Items {
 		assertVoiceMessageObject(t, &message)
@@ -201,32 +114,13 @@ func TestRequestDataForVoiceMessage(t *testing.T) {
 	}
 
 	request, err := requestDataForVoiceMessage([]string{"31612345678"}, "MyBody", voiceParams)
-	if err != nil {
-		t.Fatalf("Didn't expect error while getting request data for voice message: %s", err)
-	}
-
-	if request.Recipients[0] != "31612345678" {
-		t.Errorf("Unexpected recipient: %s, expected: 31612345678", request.Recipients[0])
-	}
-	if request.Body != "MyBody" {
-		t.Errorf("Unexpected body: %s, expected: MyBody", request.Body)
-	}
-	if request.Reference != "MyReference" {
-		t.Errorf("Unexpected reference: %s, expected: MyReference", request.Reference)
-	}
-	if request.Language != "en-gb" {
-		t.Errorf("Unexpected language: %s, expected: en-gb", request.Language)
-	}
-	if request.Voice != "male" {
-		t.Errorf("Unexpected voice: %s, expected: male", request.Voice)
-	}
-	if request.Repeat != 2 {
-		t.Errorf("Unexpected repeat: %d, expected: 2", request.Repeat)
-	}
-	if request.IfMachine != "continue" {
-		t.Errorf("Unexpected if machine: %s, expected: continue", request.IfMachine)
-	}
-	if request.ScheduledDatetime != voiceParams.ScheduledDatetime.Format(time.RFC3339) {
-		t.Errorf("Unexpected scheduled date time: %s, expected: %s", request.ScheduledDatetime, voiceParams.ScheduledDatetime.Format(time.RFC3339))
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "31612345678", request.Recipients[0])
+	assert.Equal(t, "MyBody", request.Body)
+	assert.Equal(t, "MyReference", request.Reference)
+	assert.Equal(t, "en-gb", request.Language)
+	assert.Equal(t, "male", request.Voice)
+	assert.Equal(t, 2, request.Repeat)
+	assert.Equal(t, "continue", request.IfMachine)
+	assert.Equal(t, voiceParams.ScheduledDatetime.Format(time.RFC3339), request.ScheduledDatetime)
 }


### PR DESCRIPTION
This PR introduces the usage of [testify](https://github.com/stretchr/testify) for testing this package.
This is a known and popular testing suite for Go.

It makes the tests very easy to maintain and concise.  All assertions have been simplified.  The next steps (in another PR) are to mock the responses with testify. 

——

This PR could ideally be merged after the move to Github Action cf. https://github.com/messagebird/go-rest-api/pull/96

  —-

Cc @rfeiner @CoolGoose 