### PR TITLE
ErrorResponse.Error() optimization

### DIFF
--- a/error.go
+++ b/error.go
@@ -24,9 +24,9 @@ type ErrorResponse struct {
 
 // Error implements error interface.
 func (r ErrorResponse) Error() string {
-	var inners []string
-	for _, inner := range r.Errors {
-		inners = append(inners, inner.Error())
+	inners := make([]string, len(r.Errors))
+	for i, inner := range r.Errors {
+		inners[i] = inner.Error()
 	}
 	return fmt.Sprintf("API errors: %s", strings.Join(inners, ", "))
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,8 +1,10 @@
 package messagebird
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestError(t *testing.T) {
@@ -36,4 +38,17 @@ func TestError(t *testing.T) {
 		}
 		assert.Error(t, errRes)
 	})
+}
+
+func BenchmarkErrorResponse_Error(b *testing.B) {
+	for n := 1; n <= 1024; n *= 2 {
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			errors := make([]Error, n)
+
+			for i := 0; i < b.N; i++ {
+				err := ErrorResponse{Errors: errors}
+				_ = err.Error()
+			}
+		})
+	}
 }


### PR DESCRIPTION
Hi!

I was working on tests for `ErrorResponse.Error()` function and noticed that functon could be optimized. How it looks now:

```go
func (r ErrorResponse) Error() string {
	var inners []string
	for _, inner := range r.Errors {
		inners = append(inners, inner.Error())
	}
	return fmt.Sprintf("API errors: %s", strings.Join(inners, ", "))
}
```

In line 2, we declare an empty slice and then add items to it one by one via function `append`. This function sometimes increases the capacity of the slice if there is no more free space to store new items. But we can see that slice `inners` always has the same length as `r.Errors`, so we can initialize it with concrete size.

I've written a benchmark and compared three different realizations:

1. Current - the version in `master` brach
2. Preferred Capacity - the version where we declare `inner` variable as a slice with specified capacity and zero-length
3. Preferred Size - the version where we declare `inner` variable as a slice with a specified length

Here is a comparasion of these three versions by time where X-Axis is a number of errors in `ErrorResponse.Errors` and Y-Axis is time of working `ErrorResponse.Error()` function:
<img width="639" alt="изображение" src="https://user-images.githubusercontent.com/3082586/115971122-59a64380-a54f-11eb-8509-6e1e06deefea.png">

Here is a comparison of these three versions by memory allocations where X-Axis is a number of errors in `ErrorResponse.Errors` and Y-Axis is a count of memory allocations during `ErrorResponse.Error()`:
<img width="636" alt="изображение" src="https://user-images.githubusercontent.com/3082586/115971220-ecdf7900-a54f-11eb-9ec4-52a1e51fe557.png">

I've decided to send you a pull request with optimization `ErrorResponse.Error()` by memory allocations and time.

