### PR TITLE
Update go module to v7.

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -98,6 +98,8 @@ Although those are all breaking changes, it's worth mentioning this new version 
 ### Version suffix
 To preserve import compatibility, the go command requires that modules with major version v2 or later use a module path with that major version as the final element. 
 
-So all imports of `go-rest-api` are replaced as `go-rest-api/v6`. 
+So all imports of `go-rest-api` are replaced as `go-rest-api/v6`.
 
-
+## `v6.1.0` -> `v7.0.0`
+### Verify Recipient type
+As v7 introduces support for using the Verify API with email recipients, the `Verify.Recipient` field has been changed from to a string type.

--- a/balance/balance.go
+++ b/balance/balance.go
@@ -3,7 +3,7 @@ package balance
 import (
 	"net/http"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // Balance describes your balance information.

--- a/balance/balance_test.go
+++ b/balance/balance_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	messagebird "github.com/messagebird/go-rest-api/v7"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client.go
+++ b/client.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// ClientVersion is used in User-Agent request header to provide server with API level.
-	ClientVersion = "6.0.0"
+	ClientVersion = "7.0.0"
 
 	// Endpoint points you to MessageBird REST API.
 	Endpoint = "https://rest.messagebird.com"

--- a/contact/contact.go
+++ b/contact/contact.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // Contact gets returned by the API.

--- a/contact/contact_test.go
+++ b/contact/contact_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 )
 
 func TestMain(m *testing.M) {

--- a/conversation/api.go
+++ b/conversation/api.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 const (

--- a/conversation/conversation.go
+++ b/conversation/conversation.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // ListOptions can be used to set pagination options in List().

--- a/conversation/conversation_test.go
+++ b/conversation/conversation_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conversation/message.go
+++ b/conversation/message.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 type MessageCreateRequest struct {

--- a/conversation/message_test.go
+++ b/conversation/message_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conversation/webhook.go
+++ b/conversation/webhook.go
@@ -3,7 +3,7 @@ package conversation
 import (
 	"net/http"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 type WebhookCreateRequest struct {

--- a/conversation/webhook_test.go
+++ b/conversation/webhook_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/messagebird/go-rest-api/v6
+module github.com/messagebird/go-rest-api/v7
 
 go 1.14
 
-require github.com/stretchr/testify v1.7.0 // indirect
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/group/group.go
+++ b/group/group.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
-	"github.com/messagebird/go-rest-api/v6/contact"
+	messagebird "github.com/messagebird/go-rest-api/v7"
+	"github.com/messagebird/go-rest-api/v7/contact"
 )
 
 // Group gets returned by the API.

--- a/group/group_test.go
+++ b/group/group_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/hlr/hlr.go
+++ b/hlr/hlr.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // HLR stands for Home Location Register. Contains information about the

--- a/hlr/hlr_test.go
+++ b/hlr/hlr_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/messagebird/go-rest-api/v6"
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/mbtest/test_client.go
+++ b/internal/mbtest/test_client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // testWriter can be used to have the client write to the tests's error log.

--- a/lookup/lookup.go
+++ b/lookup/lookup.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"net/url"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
-	"github.com/messagebird/go-rest-api/v6/hlr"
+	messagebird "github.com/messagebird/go-rest-api/v7"
+	"github.com/messagebird/go-rest-api/v7/hlr"
 )
 
 // Formats represents phone number in multiple formats.

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/messagebird/go-rest-api/v6/hlr"
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7/hlr"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/mms/message.go
+++ b/mms/message.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // Message represents a MMS Message.

--- a/mms/message_test.go
+++ b/mms/message_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	messagebird "github.com/messagebird/go-rest-api/v7"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/number/number.go
+++ b/number/number.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strconv"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 const (

--- a/number/number_test.go
+++ b/number/number_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/sms/message.go
+++ b/sms/message.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // TypeDetails is a hash with extra information.

--- a/sms/message_test.go
+++ b/sms/message_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	messagebird "github.com/messagebird/go-rest-api/v7"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // Verify object represents MessageBird server response.

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/voice/call.go
+++ b/voice/call.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // CallStatus enumerates all valid values for a call status.

--- a/voice/callflow.go
+++ b/voice/callflow.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/messagebird/go-rest-api/v6"
+	"github.com/messagebird/go-rest-api/v7"
 )
 
 // A CallFlow describes the flow of operations (steps) to be executed when

--- a/voice/leg.go
+++ b/voice/leg.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // LegStatus enumerates all valid values for a leg status.

--- a/voice/main_test.go
+++ b/voice/main_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 func testRequest(status int, body []byte) (*messagebird.Client, func()) {

--- a/voice/paginator.go
+++ b/voice/paginator.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"reflect"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // A Paginator is used to stream the contents of a collection of some type from

--- a/voice/recording.go
+++ b/voice/recording.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // RecordingStatus enumerates all valid values for the status of a recording.

--- a/voice/recording_test.go
+++ b/voice/recording_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/voice/transcription.go
+++ b/voice/transcription.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // A Transcription is a textual representation of a recording as text.

--- a/voice/transcription_test.go
+++ b/voice/transcription_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/voice/voice.go
+++ b/voice/voice.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 const apiRoot = "https://voice.messagebird.com/v1"

--- a/voice/voice_test.go
+++ b/voice/voice_test.go
@@ -3,7 +3,7 @@ package voice
 import (
 	"testing"
 
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/voice/webhook.go
+++ b/voice/webhook.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // A Webhook is an HTTP callback to your platform. They are sent when calls are

--- a/voicemessage/voice_message.go
+++ b/voicemessage/voice_message.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	messagebird "github.com/messagebird/go-rest-api/v6"
+	messagebird "github.com/messagebird/go-rest-api/v7"
 )
 
 // VoiceMessage wraps data needed to transform text messages into voice messages.

--- a/voicemessage/voice_message_test.go
+++ b/voicemessage/voice_message_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/messagebird/go-rest-api/v6"
-	"github.com/messagebird/go-rest-api/v6/internal/mbtest"
+	"github.com/messagebird/go-rest-api/v7"
+	"github.com/messagebird/go-rest-api/v7/internal/mbtest"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
As v7 introduces support for using the Verify API with email recipients,
the `Verify.Recipient` field has been changed from to a string type.