### PR TITLE
remove client from arguments in SMS func calls

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// ClientVersion is used in User-Agent request header to provide server with API level.
-	ClientVersion = "7.0.0"
+	ClientVersion = "7.1.0"
 
 	// Endpoint points you to MessageBird REST API.
 	Endpoint = "https://rest.messagebird.com"
@@ -40,7 +40,7 @@ const (
 
 var (
 	// ErrUnexpectedResponse is used when there was an internal server error and nothing can be done at this point.
-	ErrUnexpectedResponse = errors.New("The MessageBird API is currently unavailable")
+	ErrUnexpectedResponse = errors.New("the MessageBird API is currently unavailable")
 )
 
 // A Feature can be enabled

--- a/sms/message.go
+++ b/sms/message.go
@@ -87,9 +87,13 @@ type messageRequest struct {
 const path = "messages"
 
 // Read retrieves the information of an existing Message.
-func Read(c *messagebird.Client, id string) (*Message, error) {
+func Read(id string) (*Message, error) {
+	if err := ensureClient(); err != nil {
+		return nil, err
+	}
+
 	message := &Message{}
-	if err := c.Request(message, http.MethodGet, path+"/"+id, nil); err != nil {
+	if err := smsClient.Request(message, http.MethodGet, path+"/"+id, nil); err != nil {
 		return nil, err
 	}
 
@@ -98,8 +102,12 @@ func Read(c *messagebird.Client, id string) (*Message, error) {
 
 // Cancel sending Scheduled Sms.
 func Delete(c *messagebird.Client, id string) (*Message, error) {
+	if err := ensureClient(); err != nil {
+		return nil, err
+	}
+
 	message := &Message{}
-	if err := c.Request(message, http.MethodDelete, path+"/"+id, nil); err != nil {
+	if err := smsClient.Request(message, http.MethodDelete, path+"/"+id, nil); err != nil {
 		return nil, err
 	}
 
@@ -107,14 +115,18 @@ func Delete(c *messagebird.Client, id string) (*Message, error) {
 }
 
 // List retrieves all messages of the user represented as a MessageList object.
-func List(c *messagebird.Client, msgListParams *ListParams) (*MessageList, error) {
+func List(msgListParams *ListParams) (*MessageList, error) {
+	if err := ensureClient(); err != nil {
+		return nil, err
+	}
+
 	messageList := &MessageList{}
 	params, err := paramsForMessageList(msgListParams)
 	if err != nil {
 		return messageList, err
 	}
 
-	if err := c.Request(messageList, http.MethodGet, path+"?"+params.Encode(), nil); err != nil {
+	if err := smsClient.Request(messageList, http.MethodGet, path+"?"+params.Encode(), nil); err != nil {
 		return nil, err
 	}
 
@@ -122,14 +134,18 @@ func List(c *messagebird.Client, msgListParams *ListParams) (*MessageList, error
 }
 
 // Create creates a new message for one or more recipients.
-func Create(c *messagebird.Client, originator string, recipients []string, body string, msgParams *Params) (*Message, error) {
+func Create(originator string, recipients []string, body string, msgParams *Params) (*Message, error) {
+	if err := ensureClient(); err != nil {
+		return nil, err
+	}
+
 	requestData, err := requestDataForMessage(originator, recipients, body, msgParams)
 	if err != nil {
 		return nil, err
 	}
 
 	message := &Message{}
-	if err := c.Request(message, http.MethodPost, path, requestData); err != nil {
+	if err := smsClient.Request(message, http.MethodPost, path, requestData); err != nil {
 		return nil, err
 	}
 

--- a/sms/message_test.go
+++ b/sms/message_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
+
 	mbtest.EnableServer(m)
 }
 
@@ -44,8 +45,9 @@ func assertMessageObject(t *testing.T, message *Message) {
 func TestCreate(t *testing.T) {
 	mbtest.WillReturnTestdata(t, "messageObject.json", http.StatusOK)
 	client := mbtest.Client(t)
+	RegisterClient(client)
 
-	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", nil)
+	message, err := Create("TestName", []string{"31612345678"}, "Hello World", nil)
 	assert.NoError(t, err)
 
 	assertMessageObject(t, message)
@@ -54,8 +56,9 @@ func TestCreate(t *testing.T) {
 func TestCreateError(t *testing.T) {
 	mbtest.WillReturnAccessKeyError()
 	client := mbtest.Client(t)
+	RegisterClient(client)
 
-	_, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", nil)
+	_, err := Create("TestName", []string{"31612345678"}, "Hello World", nil)
 
 	errorResponse, ok := err.(messagebird.ErrorResponse)
 	assert.True(t, ok)
@@ -67,6 +70,7 @@ func TestCreateError(t *testing.T) {
 func TestCreateWithParams(t *testing.T) {
 	mbtest.WillReturnTestdata(t, "messageWithParamsObject.json", http.StatusOK)
 	client := mbtest.Client(t)
+	RegisterClient(client)
 
 	params := &Params{
 		Type:       "sms",
@@ -76,7 +80,7 @@ func TestCreateWithParams(t *testing.T) {
 		DataCoding: "unicode",
 	}
 
-	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", params)
+	message, err := Create("TestName", []string{"31612345678"}, "Hello World", params)
 	assert.NoError(t, err)
 	assert.Equal(t, "sms", message.Type)
 	assert.Equal(t, "TestReference", message.Reference)
@@ -88,13 +92,14 @@ func TestCreateWithParams(t *testing.T) {
 func TestCreateWithBinaryType(t *testing.T) {
 	mbtest.WillReturnTestdata(t, "binaryMessageObject.json", http.StatusOK)
 	client := mbtest.Client(t)
+	RegisterClient(client)
 
 	params := &Params{
 		Type:        "binary",
 		TypeDetails: TypeDetails{"udh": "050003340201"},
 	}
 
-	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", params)
+	message, err := Create("TestName", []string{"31612345678"}, "Hello World", params)
 	assert.NoError(t, err)
 	assert.Equal(t, "binary", message.Type)
 	assert.Len(t, message.TypeDetails, 1)
@@ -104,13 +109,14 @@ func TestCreateWithBinaryType(t *testing.T) {
 func TestCreateWithPremiumType(t *testing.T) {
 	mbtest.WillReturnTestdata(t, "premiumMessageObject.json", http.StatusOK)
 	client := mbtest.Client(t)
+	RegisterClient(client)
 
 	params := &Params{
 		Type:        "premium",
 		TypeDetails: TypeDetails{"keyword": "RESTAPI", "shortcode": 1008, "tariff": 150},
 	}
 
-	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", params)
+	message, err := Create("TestName", []string{"31612345678"}, "Hello World", params)
 	assert.NoError(t, err)
 	assert.Equal(t, "premium", message.Type)
 	assert.Equal(t, 3, len(message.TypeDetails))
@@ -122,10 +128,11 @@ func TestCreateWithPremiumType(t *testing.T) {
 func TestCreateWithFlashType(t *testing.T) {
 	mbtest.WillReturnTestdata(t, "flashMessageObject.json", http.StatusOK)
 	client := mbtest.Client(t)
+	RegisterClient(client)
 
 	params := &Params{Type: "flash"}
 
-	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", params)
+	message, err := Create("TestName", []string{"31612345678"}, "Hello World", params)
 	assert.NoError(t, err)
 	assert.Equal(t, "flash", message.Type)
 }
@@ -133,12 +140,13 @@ func TestCreateWithFlashType(t *testing.T) {
 func TestCreateWithScheduledDatetime(t *testing.T) {
 	mbtest.WillReturnTestdata(t, "messageObjectWithCreatedDatetime.json", http.StatusOK)
 	client := mbtest.Client(t)
+	RegisterClient(client)
 
 	scheduledDatetime, _ := time.Parse(time.RFC3339, "2015-01-05T10:03:59+00:00")
 
 	params := &Params{ScheduledDatetime: scheduledDatetime}
 
-	message, err := Create(client, "TestName", []string{"31612345678"}, "Hello World", params)
+	message, err := Create("TestName", []string{"31612345678"}, "Hello World", params)
 	assert.NoError(t, err)
 	assert.Equal(t, scheduledDatetime.Format(time.RFC3339), message.ScheduledDatetime.Format(time.RFC3339))
 	assert.Equal(t, 1, message.Recipients.TotalCount)
@@ -151,8 +159,9 @@ func TestCreateWithScheduledDatetime(t *testing.T) {
 func TestList(t *testing.T) {
 	mbtest.WillReturnTestdata(t, "messageListObject.json", http.StatusOK)
 	client := mbtest.Client(t)
+	RegisterClient(client)
 
-	messageList, err := List(client, nil)
+	messageList, err := List(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, messageList.Offset)
 	assert.Equal(t, 20, messageList.Limit)
@@ -177,9 +186,10 @@ func TestListScheduled(t *testing.T) {
 	defer teardown()
 
 	client := mbtest.Client(t)
+	RegisterClient(client)
 	client.HTTPClient.Transport = transport
 
-	messageList, err := List(client, &ListParams{Status: "scheduled"})
+	messageList, err := List(&ListParams{Status: "scheduled"})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, messageList.Count)
 	assert.Equal(t, 1, messageList.TotalCount)

--- a/sms/sms.go
+++ b/sms/sms.go
@@ -1,0 +1,33 @@
+package sms
+
+import (
+	"errors"
+	"sync"
+)
+
+type SMSClient interface {
+	Request(v interface{}, method, path string, data interface{}) error
+}
+
+var smsClient SMSClient
+var mu sync.Mutex
+
+func RegisterClient(c SMSClient) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	smsClient = c
+}
+
+var errNoClient = errors.New("no client is set")
+
+func ensureClient() error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if smsClient == nil {
+		return errNoClient
+	}
+
+	return nil
+}


### PR DESCRIPTION
first of, this PR should address issue raised in https://github.com/messagebird/go-rest-api/issues/110

Additionally, the PR introduces way to set `Client` on package level thus removing a need to pass it in arguments every time.

P.S.
i bump version to  7.1.0 but it seems we need new version since it changes an arity of a function