### PR TITLE
Add Create V2 API for SMS that returns http response

### DIFF
--- a/internal/mbtest/test_client.go
+++ b/internal/mbtest/test_client.go
@@ -2,11 +2,12 @@ package mbtest
 
 import (
 	"crypto/tls"
-	"github.com/stretchr/testify/mock"
 	"log"
 	"net"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
 
 	messagebird "github.com/messagebird/go-rest-api/v9"
 )
@@ -24,6 +25,10 @@ func (c *ClientMock) IsFeatureEnabled(feature messagebird.Feature) bool {
 }
 func (c *ClientMock) Request(v interface{}, method, path string, data interface{}) error {
 	return nil
+}
+
+func (c *ClientMock) RequestV2(v interface{}, method, path string, data interface{}) (*http.Response, error) {
+	return nil, nil
 }
 
 // MockClient initializes a new mock of MessageBird client

--- a/sms/message.go
+++ b/sms/message.go
@@ -164,6 +164,22 @@ func Create(c messagebird.Client, originator string, recipients []string, body s
 	return message, nil
 }
 
+// CreateV2 creates a new message for one or more recipients and returns http response of the request
+func CreateV2(c messagebird.Client, originator string, recipients []string, body string, msgParams *Params) (*Message, *http.Response, error) {
+	requestData, err := paramsToRequest(originator, recipients, body, msgParams)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	message := &Message{}
+	resp, err := c.RequestV2(message, http.MethodPost, path, requestData)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return message, resp, nil
+}
+
 func paramsToRequest(originator string, recipients []string, body string, params *Params) (*messageRequest, error) {
 	if originator == "" {
 		return nil, errors.New("originator is required")


### PR DESCRIPTION
This change adds a new `CreateV2` to the SMS module, that returns the HTTP response  along with the message object