### PR TITLE
Add maxAttempts param to verify API

### DIFF
--- a/verify/verify.go
+++ b/verify/verify.go
@@ -36,6 +36,7 @@ type Params struct {
 	Timeout     int
 	TokenLength int
 	Subject     string
+	MaxAttempts int
 }
 
 type verifyRequest struct {
@@ -51,6 +52,7 @@ type verifyRequest struct {
 	Timeout     int    `json:"timeout,omitempty"`
 	TokenLength int    `json:"tokenLength,omitempty"`
 	Subject     string `json:"subject,omitempty"`
+	MaxAttempts int    `json:"maxAttempts,omitempty"`
 }
 
 // Create generates a new One-Time-Password for one recipient.
@@ -129,6 +131,7 @@ func paramsToVerifyRequest(recipient string, params *Params) (*verifyRequest, er
 	request.Timeout = params.Timeout
 	request.TokenLength = params.TokenLength
 	request.Subject = params.Subject
+	request.MaxAttempts = params.MaxAttempts
 
 	return request, nil
 }

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -108,6 +108,7 @@ func TestRequestDataForVerify(t *testing.T) {
 		Language:    "en-gb",
 		Timeout:     20,
 		TokenLength: 8,
+		MaxAttempts: 3,
 	}
 
 	requestData, err := paramsToVerifyRequest("31612345678", verifyParams)
@@ -122,4 +123,5 @@ func TestRequestDataForVerify(t *testing.T) {
 	assert.Equal(t, "en-gb", requestData.Language)
 	assert.Equal(t, 20, requestData.Timeout)
 	assert.Equal(t, 8, requestData.TokenLength)
+	assert.Equal(t, 3, requestData.MaxAttempts)
 }


### PR DESCRIPTION
Hello,

In the message bird documentation, there is a maxAttempts option parameter which sets the maximum number of token input attempts a user can do before the Verify object is marked as failed.
This PR is an attempt to provide that through the Params struct allowing whoever uses the library to set it.